### PR TITLE
fix: unit test names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ The comparators in each level are in the `src/comparator` folder, for example: `
 A single unit test can be run by this command: 
 
 ```sh
-python -m unittest test.comparator.test_enun_comparator
+python -m unittest test.comparator.test_enum_comparator
 ```
 
 All unit tests can be run by this command: 

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -1,7 +1,6 @@
 from google.protobuf.descriptor_pb2 import FieldDescriptorProto
 from src.findings.finding_container import FindingContainer
 from src.findings.utils import FindingCategory
-import google.api.resource_pb2 as pb2
 import google.protobuf.descriptor_pb2 as descriptor_pb2
 
 class FieldComparator:

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -14,25 +14,25 @@ class EnumComparatorTest(unittest.TestCase):
     def tearDown(self):
         FindingContainer.reset()
 
-    def enumRemoval(self):
+    def test_enum_removal(self):
         EnumComparator(self.enum_original, None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'An Enum PhoneType is removed')
         self.assertEqual(finding.category.name, 'ENUM_REMOVAL')
 
-    def enumAddition(self):
+    def test_enum_addition(self):
         EnumComparator(None, self.enum_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'A new Enum PhoneTypeUpdate is added.')
         self.assertEqual(finding.category.name, 'ENUM_ADDITION')
     
-    def enumNameChange(self):
+    def test_enum_name_change(self):
         EnumComparator(self.enum_original, self.enum_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'Name of the Enum is changed, the original is PhoneType, but the updated is PhoneTypeUpdate')
         self.assertEqual(finding.category.name, 'ENUM_NAME_CHANGE')
             
-    def oApiChange(self):
+    def test_no_api_change(self):
         EnumComparator(self.enum_update, self.enum_update).compare()
         self.assertEqual(len(FindingContainer.getAllFindings()), 0)
 

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -14,26 +14,26 @@ class EnumValueComparatorTest(unittest.TestCase):
     def tearDown(self):
         FindingContainer.reset()
 
-    def enumValueRemoval(self):
+    def test_enum_value_removal(self):
         EnumValueComparator(self.enumValue_mobile, None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'An EnumValue MOBILE is removed')
         self.assertEqual(finding.category.name, 'ENUM_VALUE_REMOVAL')
 
 
-    def enumValueAddition(self):
+    def test_enum_value_addition(self):
         EnumValueComparator(None, self.enumValue_home).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'A new EnumValue HOME is added.')
         self.assertEqual(finding.category.name, 'ENUM_VALUE_ADDITION')
 
-    def enumValueNameChange(self):
+    def test_name_change(self):
         EnumValueComparator(self.enumValue_mobile, self.enumValue_home).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'Name of the EnumValue is changed, the original is MOBILE, but the updated is HOME')
         self.assertEqual(finding.category.name, 'ENUM_VALUE_NAME_CHANGE')
 
-    def noApiChange(self):
+    def test_no_api_change(self):
         EnumValueComparator(self.enumValue_mobile, self.enumValue_mobile).compare()
         self.assertEqual(len(FindingContainer.getAllFindings()), 0)
 

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -10,21 +10,21 @@ class FieldComparatorTest(unittest.TestCase):
     def tearDown(self):
         FindingContainer.reset()
 
-    def fieldRemoval(self):
+    def test_field_removal(self):
         field_company_address = update_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['company_address']
         FieldComparator(field_company_address, None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'A Field company_address is removed')
         self.assertEqual(finding.category.name, 'FIELD_REMOVAL')
 
-    def fieldAddition(self):
+    def test_field_addition(self):
         field_married = update_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['married']
         FieldComparator(None, field_married).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'A new Field married is added.')
         self.assertEqual(finding.category.name, 'FIELD_ADDITION')
 
-    def typeChange(self):
+    def test_type_change(self):
         field_id_original = original_version.DESCRIPTOR.message_types_by_name["Person"].fields[1]
         field_id_update = update_version.DESCRIPTOR.message_types_by_name["Person"].fields[1]
         FieldComparator(field_id_original, field_id_update).compare()
@@ -32,7 +32,7 @@ class FieldComparatorTest(unittest.TestCase):
         self.assertEqual(finding.message, 'Type of the Field is changed, the original is TYPE_INT32, but the updated is TYPE_STRING')
         self.assertEqual(finding.category.name, 'FIELD_TYPE_CHANGE')
 
-    def repeatedLabelChange(self):
+    def test_repeated_label_change(self):
         field_phones_original = original_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['phones']
         field_phones_update = update_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['phones']
         FieldComparator(field_phones_original, field_phones_update).compare()
@@ -40,7 +40,7 @@ class FieldComparatorTest(unittest.TestCase):
         self.assertEqual(finding.message, 'Repeated state of the Field is changed, the original is LABEL_REPEATED, but the updated is LABEL_OPTIONAL')
         self.assertEqual(finding.category.name, 'FIELD_REPEATED_CHANGE')
 
-    def nameChange(self):
+    def test_name_change(self):
         field_email_original = original_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['email']
         field_email_update = update_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['email_address']
         FieldComparator(field_email_original, field_email_update).compare()
@@ -48,7 +48,7 @@ class FieldComparatorTest(unittest.TestCase):
         self.assertEqual(finding.message, 'Name of the Field is changed, the original is email, but the updated is email_address')
         self.assertEqual(finding.category.name, 'FIELD_NAME_CHANGE')
 
-    def moveExistingFieldOutofOneof(self):
+    def test_move_existing_out_of_oneof(self):
         field_email_original = original_version.DESCRIPTOR.message_types_by_name["AddressBook"].fields_by_name['deprecated']
         field_email_update = update_version.DESCRIPTOR.message_types_by_name["AddressBook"].fields_by_name['deprecated']
         FieldComparator(field_email_original, field_email_update).compare()
@@ -56,7 +56,7 @@ class FieldComparatorTest(unittest.TestCase):
         self.assertEqual(finding.message, 'The Field deprecated is moved out of one-of')
         self.assertEqual(finding.category.name, 'FIELD_ONEOF_REMOVAL')
 
-    def moveExistingFieldIntoOneof(self):
+    def test_move_existing_field_into_oneof(self):
         field_email_original = original_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['home_address']
         field_email_update = update_version.DESCRIPTOR.message_types_by_name["Person"].fields_by_name['home_address']
         FieldComparator(field_email_original, field_email_update).compare()

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -15,25 +15,25 @@ class DescriptorComparatorTest(unittest.TestCase):
     def tearDown(self):
         FindingContainer.reset()
 
-    def messageRemoval(self):
+    def test_message_removal(self):
         DescriptorComparator(self.person_msg, None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'A message Person is removed')
         self.assertEqual(finding.category.name, 'MESSAGE_REMOVAL')
 
-    def messageAddition(self):
+    def test_message_addition(self):
         DescriptorComparator(None, self.addressBook_msg).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'A new message AddressBook is added.')
         self.assertEqual(finding.category.name, 'MESSAGE_ADDITION')  
 
-    def fieldChange(self):
+    def test_field_change(self):
         DescriptorComparator(self.addressBook_msg, self.addressBook_msg_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, 'The Field deprecated is moved out of one-of')
         self.assertEqual(finding.category.name, 'FIELD_ONEOF_REMOVAL')  
 
-    def nestedMessageChange(self):
+    def test_nested_message_change(self):
         # Field `type` in nested message `PhoneNumber` is re-numbered. So it is taken as one field removed and one field added.
         DescriptorComparator(self.person_msg, self.person_msg_update).compare()
         findingLength = len(FindingContainer.getAllFindings())


### PR DESCRIPTION
Apparently, python `unittest` module does not recognize unit tests that are not named as `test_*` :)

Now we can run unit test by 
```
>> python -m unittest test.comparator.test_enum_comparator
>> python -m unittest discover test/comparator/
```
and output is like below:
```
...................
----------------------------------------------------------------------
Ran 19 tests in 0.002s

OK
```
The updates for unit test framework will be coming, then we will use object defined by `descriptor_pb2` as testdata.