### PR TITLE
refactor!: update comparator and unit tests to use data class wrappers

### DIFF
--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.protobuf.descriptor_pb2 import EnumDescriptorProto
 from src.comparator.enum_value_comparator import EnumValueComparator
 from src.findings.finding_container import FindingContainer
 from src.findings.utils import FindingCategory
+from src.comparator.wrappers import Enum
 
 
 class EnumComparator:
-    def __init__(
-        self, enum_original: EnumDescriptorProto, enum_update: EnumDescriptorProto
-    ):
+    def __init__(self, enum_original: Enum, enum_update: Enum):
         self.enum_original = enum_original
         self.enum_update = enum_update
 
@@ -47,8 +45,8 @@ class EnumComparator:
         # of them stay the same. Enum values are identified by number,
         # not by name.
         else:
-            enum_values_dict_original = {x.number: x for x in self.enum_original.value}
-            enum_values_dict_update = {x.number: x for x in self.enum_update.value}
+            enum_values_dict_original = self.enum_original.values
+            enum_values_dict_update = self.enum_update.values
             enum_values_keys_set_original = set(enum_values_dict_original.keys())
             enum_values_keys_set_update = set(enum_values_dict_update.keys())
             # Compare Enum values that only exist in original version

--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.protobuf.descriptor_pb2 import EnumValueDescriptorProto
 from src.findings.finding_container import FindingContainer
 from src.findings.utils import FindingCategory
+from src.comparator.wrappers import EnumValue
 
 
 class EnumValueComparator:
     def __init__(
         self,
-        enum_value_original: EnumValueDescriptorProto,
-        enum_value_update: EnumValueDescriptorProto,
+        enum_value_original: EnumValue,
+        enum_value_update: EnumValue,
     ):
         self.enum_value_original = enum_value_original
         self.enum_value_update = enum_value_update

--- a/src/comparator/message_comparator.py
+++ b/src/comparator/message_comparator.py
@@ -26,12 +26,6 @@ class DescriptorComparator:
     ):
         self.message_original = message_original
         self.message_update = message_update
-        self.global_resources_original = (
-            message_original.file_resources if message_original else None
-        )
-        self.global_resources_update = (
-            message_update.file_resources if message_update else None
-        )
 
     def compare(self):
         # _compare method will be recursively called for nested message comparison.
@@ -51,6 +45,8 @@ class DescriptorComparator:
             FindingContainer.addFinding(FindingCategory.MESSAGE_REMOVAL, "", msg, True)
             return
 
+        self.global_resources_original = self.message_original.file_resources
+        self.global_resources_update = self.message_update.file_resources
         # 3. Check breaking changes in each fields. Note: Fields are
         # identified by number, not by name. Descriptor.fields_by_number
         # (dict int -> FieldDescriptor) indexed by number.

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -89,6 +89,11 @@ class Field:
         return self.field_pb.name
 
     @property
+    def number(self):
+        """Return the number of the field."""
+        return self.field_pb.number
+
+    @property
     def label(self):
         """Return the label of the field.
 
@@ -225,10 +230,20 @@ class Method:
         return self.method_pb.output_type.endswith(".google.longrunning.Operation")
 
     @property
+    def client_streaming(self) -> bool:
+        """Return True if this is a client-streamign method."""
+        return self.method_pb.client_streaming
+
+    @property
+    def server_streaming(self) -> bool:
+        """Return True if this is a server-streaming method."""
+        return self.method_pb.server_streaming
+
+    @property
     def paged_result_field(self) -> Optional[FieldDescriptorProto]:
         """Return the response pagination field if the method is paginated."""
         # (AIP 158) The response must not be a streaming response for a paginated method.
-        if self.method_pb.server_streaming:
+        if self.server_streaming:
             return None
         # If the output type is `google.longrunning.Operation`, the method is not paginated.
         if self.longrunning:
@@ -249,7 +264,7 @@ class Method:
             (response_fields_map, "TYPE_STRING", "next_page_token"),
         ):
             field = page_field[0].get(page_field[2], None)
-            if not field or field.type != page_field[1]:
+            if not field or field.proto_type != page_field[1]:
                 return None
 
         # Return the first repeated field.

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -16,6 +16,7 @@ import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.enum_comparator import EnumComparator
 from src.findings.finding_container import FindingContainer
+from src.comparator.wrappers import Enum
 
 
 class EnumComparatorTest(unittest.TestCase):
@@ -37,8 +38,8 @@ class EnumComparatorTest(unittest.TestCase):
     def setUp(self):
         # We take the enumDescriptorProto `phoneType` and `phoneTypeUpdate` from the original
         # and updated `_descriptor_set.pb` files for comparison.
-        self.enum_original = self._PB_ORIGNAL.file[0].message_type[0].enum_type[0]
-        self.enum_update = self._PB_UPDATE.file[0].message_type[0].enum_type[0]
+        self.enum_original = Enum(self._PB_ORIGNAL.file[0].message_type[0].enum_type[0])
+        self.enum_update = Enum(self._PB_UPDATE.file[0].message_type[0].enum_type[0])
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -16,6 +16,7 @@ import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.enum_value_comparator import EnumValueComparator
 from src.findings.finding_container import FindingContainer
+from src.comparator.wrappers import EnumValue
 
 
 class EnumValueComparatorTest(unittest.TestCase):
@@ -33,8 +34,8 @@ class EnumValueComparatorTest(unittest.TestCase):
     def setUp(self):
         # Get `MOBILE` and `HOME` enumValueDescriptorProto from `message_v1_descriptor_set.pb`.
         enum_type_values = self._PB_ORIGNAL.file[0].message_type[0].enum_type[0].value
-        self.enumValue_mobile = enum_type_values[0]
-        self.enumValue_home = enum_type_values[1]
+        self.enumValue_mobile = EnumValue(enum_type_values[0])
+        self.enumValue_home = EnumValue(enum_type_values[1])
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -15,6 +15,7 @@
 import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.field_comparator import FieldComparator
+from src.comparator.wrappers import Field
 from src.findings.finding_container import FindingContainer
 
 
@@ -39,14 +40,14 @@ class FieldComparatorTest(unittest.TestCase):
 
     def test_field_removal(self):
         name_field = self._PB_ORIGNAL.file[0].message_type[0].field[0]
-        FieldComparator(name_field, None).compare()
+        FieldComparator(Field(name_field), None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A Field name is removed")
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
 
     def test_field_addition(self):
         name_field = self._PB_ORIGNAL.file[0].message_type[0].field[0]
-        FieldComparator(None, name_field).compare()
+        FieldComparator(None, Field(name_field)).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Field name is added.")
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
@@ -54,8 +55,8 @@ class FieldComparatorTest(unittest.TestCase):
     def test_type_change(self):
         # Field `id` is `int32` type in `message_v1.proto`,
         # but updated to `string` in `message_v1beta1.proto`.
-        field_id_original = self._PB_ORIGNAL.file[0].message_type[0].field[1]
-        field_id_update = self._PB_UPDATE.file[0].message_type[0].field[1]
+        field_id_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[1])
+        field_id_update = Field(self._PB_UPDATE.file[0].message_type[0].field[1])
         FieldComparator(field_id_original, field_id_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
@@ -68,8 +69,8 @@ class FieldComparatorTest(unittest.TestCase):
     def test_repeated_label_change(self):
         # Field `phones` in `message_v1.proto` has `repeated` label,
         # but it's removed in the `message_v1beta1.proto`.
-        field_phones_original = self._PB_ORIGNAL.file[0].message_type[0].field[3]
-        field_phones_update = self._PB_UPDATE.file[0].message_type[0].field[3]
+        field_phones_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[3])
+        field_phones_update = Field(self._PB_UPDATE.file[0].message_type[0].field[3])
         FieldComparator(field_phones_original, field_phones_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
@@ -82,8 +83,8 @@ class FieldComparatorTest(unittest.TestCase):
     def test_name_change(self):
         # Field `email = 3` in `message_v1.proto` is renamed to
         # `email_address = 3` in the `message_v1beta1.proto`.
-        field_email_original = self._PB_ORIGNAL.file[0].message_type[0].field[2]
-        field_email_update = self._PB_UPDATE.file[0].message_type[0].field[2]
+        field_email_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[2])
+        field_email_update = Field(self._PB_UPDATE.file[0].message_type[0].field[2])
         FieldComparator(field_email_original, field_email_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
@@ -94,8 +95,8 @@ class FieldComparatorTest(unittest.TestCase):
 
     def test_oneof_change(self):
         # Field `single = 5` in `message_v1.proto` is moved out of One-of.
-        field_single_original = self._PB_ORIGNAL.file[0].message_type[0].field[4]
-        field_single_update = self._PB_UPDATE.file[0].message_type[0].field[4]
+        field_single_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[4])
+        field_single_update = Field(self._PB_UPDATE.file[0].message_type[0].field[4])
         FieldComparator(field_single_original, field_single_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -16,7 +16,7 @@ import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.file_set_comparator import FileSetComparator
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.comparator.wrappers import FileSet
 
 
 class FileSetComparatorTest(unittest.TestCase):
@@ -35,7 +35,9 @@ class FileSetComparatorTest(unittest.TestCase):
         _INVOKER_UPDATE = UnittestInvoker(
             ["service_v1beta1.proto"], "service_v1beta1_descriptor_set.pb"
         )
-        FileSetComparator(_INVOKER_ORIGNAL.run(), _INVOKER_UPDATE.run()).compare()
+        FileSetComparator(
+            FileSet(_INVOKER_ORIGNAL.run()), FileSet(_INVOKER_UPDATE.run())
+        ).compare()
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         self.assertEqual(
             findings_map[
@@ -53,7 +55,9 @@ class FileSetComparatorTest(unittest.TestCase):
         _INVOKER_UPDATE = UnittestInvoker(
             ["message_v1beta1.proto"], "message_v1beta1_descriptor_set.pb"
         )
-        FileSetComparator(_INVOKER_ORIGNAL.run(), _INVOKER_UPDATE.run()).compare()
+        FileSetComparator(
+            FileSet(_INVOKER_ORIGNAL.run()), FileSet(_INVOKER_UPDATE.run())
+        ).compare()
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         self.assertEqual(
             findings_map[
@@ -71,7 +75,9 @@ class FileSetComparatorTest(unittest.TestCase):
         _INVOKER_UPDATE = UnittestInvoker(
             ["enum_v1beta1.proto"], "enum_v1beta1_descriptor_set.pb"
         )
-        FileSetComparator(_INVOKER_ORIGNAL.run(), _INVOKER_UPDATE.run()).compare()
+        FileSetComparator(
+            FileSet(_INVOKER_ORIGNAL.run()), FileSet(_INVOKER_UPDATE.run())
+        ).compare()
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         self.assertEqual(
             findings_map["An Enum BookType is removed"].category.name,
@@ -91,7 +97,9 @@ class FileSetComparatorTest(unittest.TestCase):
             "resource_database_v1beta1_descriptor_set.pb",
             True,
         )
-        FileSetComparator(_INVOKER_ORIGNAL.run(), _INVOKER_UPDATE.run()).compare()
+        FileSetComparator(
+            FileSet(_INVOKER_ORIGNAL.run()), FileSet(_INVOKER_UPDATE.run())
+        ).compare()
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         self.assertEqual(
             findings_map[
@@ -131,7 +139,9 @@ class FileSetComparatorTest(unittest.TestCase):
             "resource_reference_v1beta1_descriptor_set.pb",
             True,
         )
-        FileSetComparator(_INVOKER_ORIGNAL.run(), _INVOKER_UPDATE.run()).compare()
+        FileSetComparator(
+            FileSet(_INVOKER_ORIGNAL.run()), FileSet(_INVOKER_UPDATE.run())
+        ).compare()
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         self.assertEqual(
             findings_map[

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -15,6 +15,7 @@
 import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.message_comparator import DescriptorComparator
+from src.comparator.wrappers import Message
 from src.findings.finding_container import FindingContainer
 
 
@@ -37,10 +38,10 @@ class DescriptorComparatorTest(unittest.TestCase):
     def setUp(self):
         # Get `Person` and `AddressBook` DescriptoProto from the
         # original and updated `*_descriptor_set.pb` files.
-        self.person_msg = self._PB_ORIGNAL.file[0].message_type[0]
-        self.person_msg_update = self._PB_UPDATE.file[0].message_type[0]
-        self.addressBook_msg = self._PB_ORIGNAL.file[0].message_type[1]
-        self.addressBook_msg_update = self._PB_UPDATE.file[0].message_type[1]
+        self.person_msg = Message(self._PB_ORIGNAL.file[0].message_type[0])
+        self.person_msg_update = Message(self._PB_UPDATE.file[0].message_type[0])
+        self.addressBook_msg = Message(self._PB_ORIGNAL.file[0].message_type[1])
+        self.addressBook_msg_update = Message(self._PB_UPDATE.file[0].message_type[1])
 
     def tearDown(self):
         FindingContainer.reset()


### PR DESCRIPTION
1. Use Wrapper class in the comparator
2. Update unit test to pass wrapper class to the comparator, the existing tests should still have expected breaking changes.