### PR TITLE
feat: add source code location information for wrappers

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -58,6 +58,7 @@ class EnumValue:
     def source_code_line(self):
         """Return the start line number of source code in the proto file. This is zero-based."""
         location = self.source_code_locations[self.path]
+        # The line number is zero-based, +1 to get the actual line number in .proto file.
         return location.span[0] + 1
 
 
@@ -86,6 +87,8 @@ class Enum:
         Returns:
             Dict[int, EnumValue]: EnumValue is identified by number.
         """
+        # EnumDescriptorProto.value has field number 2.
+        # So we append (2, value_index) to the path.
         return {
             enum_value.number: EnumValue(
                 enum_value,
@@ -226,6 +229,8 @@ class Message:
         Returns:
             Dict[int, Field]: Field is identified by number.
         """
+        # DescriptorProto.field has field number 2.
+        # So we append (2, field_index) to the path.
         return {
             field.number: Field(
                 field,
@@ -245,6 +250,8 @@ class Message:
     @property
     def nested_messages(self) -> Dict[str, "Message"]:
         """Return the nested messsages in the message. Message is identified by name."""
+        # DescriptorProto.nested_type has field number 3.
+        # So we append (3, nested_message_index) to the path.
         return {
             message.name: Message(
                 message,
@@ -263,6 +270,8 @@ class Message:
     @property
     def nested_enums(self) -> Dict[str, Enum]:
         """Return the nested enums in the message. Enum is identified by name."""
+        # DescriptorProto.enum_type has field number 4.
+        # So we append (4, nested_enum_index) to the path.
         return {
             enum.name: Enum(
                 enum,
@@ -476,6 +485,8 @@ class Service:
     @property
     def methods(self) -> Dict[str, Method]:
         """Return the methods defined in the service. Method is identified by name."""
+        # ServiceDescriptorProto.method has field number 2.
+        # So we append (2, method_index) to the path.
         return {
             method.name: Method(
                 method,

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -31,10 +31,20 @@ from google.protobuf.descriptor_pb2 import FieldDescriptorProto
 from src.comparator.resource_database import ResourceDatabase
 from typing import Dict, Sequence, Optional, Tuple
 
-# TODO(xiaozhenliu): parse SourceCode location in each descriptor.
+
+# TODO(xiaozhenliu): parse SourceCode location for properties in each descriptor.
+# For example: during comparison, we will need the source code line number for method.input.
+# The annotations cannot precisely located, because they are customized options, and we
+# use field number to get the location. For extension options, they share the same path [..., 1000].
 @dataclasses.dataclass(frozen=True)
 class EnumValue:
-    """Description of an enum value."""
+    """Description of an enum value.
+
+    proto_file_name: the proto file where the EnumValue exists.
+    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    path: the path to the EnumValue, by querying the above dictionary using the path,
+          we can get the location information.
+    """
 
     enum_value_pb: descriptor_pb2.EnumValueDescriptorProto
     proto_file_name: str
@@ -53,7 +63,13 @@ class EnumValue:
 
 @dataclasses.dataclass(frozen=True)
 class Enum:
-    """Description of an enum."""
+    """Description of an enum.
+
+    proto_file_name: the proto file where the Enum exists.
+    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    path: the path to the Enum, by querying the above dictionary using the path,
+          we can get the location information.
+    """
 
     enum_pb: descriptor_pb2.EnumDescriptorProto
     proto_file_name: str
@@ -88,7 +104,13 @@ class Enum:
 
 
 class Field:
-    """Description of a field."""
+    """Description of a field.
+
+    proto_file_name: the proto file where the Field exists.
+    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    path: the path to the Field, by querying the above dictionary using the path,
+          we can get the location information.
+    """
 
     def __init__(
         self,
@@ -169,7 +191,13 @@ class Field:
 
 
 class Message:
-    """Description of a message (defined with the ``message`` keyword)."""
+    """Description of a message (defined with the ``message`` keyword).
+
+    proto_file_name: the proto file where the Message exists.
+    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    path: the path to the Message, by querying the above dictionary using the path,
+          we can get the location information.
+    """
 
     def __init__(
         self,
@@ -268,7 +296,13 @@ class Message:
 
 
 class Method:
-    """Description of a method (defined with the ``rpc`` keyword)."""
+    """Description of a method (defined with the ``rpc`` keyword).
+
+    proto_file_name: the proto file where the Method exists.
+    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    path: the path to the Method, by querying the above dictionary using the path,
+          we can get the location information.
+    """
 
     def __init__(
         self,
@@ -411,7 +445,13 @@ class Method:
 
 
 class Service:
-    """Description of a service (defined with the ``service`` keyword)."""
+    """Description of a service (defined with the ``service`` keyword).
+
+    proto_file_name: the proto file where the Service exists.
+    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    path: the path to the MethServiceod, by querying the above dictionary using the path,
+          we can get the location information.
+    """
 
     def __init__(
         self,
@@ -507,6 +547,7 @@ class FileSet:
             ] = {}
             for location in fd.source_code_info.location:
                 source_code_locations[tuple(location.path)] = location
+
             # Create packaging options map and duplicate the per-language rules for namespaces.
             self.packaging_options_map = self._get_packaging_options_map(fd.options)
             for resource in fd.options.Extensions[resource_pb2.resource_definition]:

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -56,9 +56,9 @@ class EnumValue:
 
     @property
     def source_code_line(self):
-        """Return the start line number of source code in the proto file. This is zero-based."""
+        """Return the start line number of source code in the proto file."""
         location = self.source_code_locations[self.path]
-        # The line number is zero-based, +1 to get the actual line number in .proto file.
+        # The line number in `span` is zero-based, +1 to get the actual line number in .proto file.
         return location.span[0] + 1
 
 
@@ -101,7 +101,7 @@ class Enum:
 
     @property
     def source_code_line(self):
-        """Return the start line number of source code in the proto file. This is zero-based."""
+        """Return the start line number of source code in the proto file."""
         location = self.source_code_locations[self.path]
         return location.span[0] + 1
 
@@ -193,7 +193,7 @@ class Field:
 
     @property
     def source_code_line(self):
-        """Return the start line number of source code in the proto file. This is zero-based."""
+        """Return the start line number of source code in the proto file."""
         location = self.source_code_locations[self.path]
         return location.span[0] + 1
 
@@ -227,6 +227,7 @@ class Message:
     def name(self) -> str:
         return self.message_pb.name
 
+    # fmt: off
     @property
     def fields(self) -> Dict[int, Field]:
         """Return fields in this message.
@@ -241,11 +242,7 @@ class Message:
                 field,
                 self.proto_file_name,
                 self.source_code_locations,
-                self.path
-                + (
-                    2,
-                    i,
-                ),
+                self.path + (2, i,),
                 self.file_resources,
                 self.resource,
             )
@@ -262,11 +259,7 @@ class Message:
                 message,
                 self.proto_file_name,
                 self.source_code_locations,
-                self.path
-                + (
-                    3,
-                    i,
-                ),
+                self.path + (3, i,),
                 self.file_resources,
             )
             for i, message in enumerate(self.message_pb.nested_type)
@@ -282,14 +275,11 @@ class Message:
                 enum,
                 self.proto_file_name,
                 self.source_code_locations,
-                self.path
-                + (
-                    4,
-                    i,
-                ),
+                self.path + (4, i,),
             )
             for i, enum in enumerate(self.message_pb.enum_type)
         }
+    # fmt: on
 
     @property
     def oneof_fields(self) -> Sequence[Field]:
@@ -304,7 +294,7 @@ class Message:
 
     @property
     def source_code_line(self):
-        """Return the start line number of source code in the proto file. This is zero-based."""
+        """Return the start line number of source code in the proto file."""
         location = self.source_code_locations[self.path]
         return location.span[0] + 1
 
@@ -463,7 +453,7 @@ class Method:
 
     @property
     def source_code_line(self):
-        """Return the start line number of source code in the proto file. This is zero-based."""
+        """Return the start line number of source code in the proto file."""
         location = self.source_code_locations[self.path]
         return location.span[0] + 1
 
@@ -502,20 +492,18 @@ class Service:
         """Return the methods defined in the service. Method is identified by name."""
         # ServiceDescriptorProto.method has field number 2.
         # So we append (2, method_index) to the path.
+        # fmt: off
         return {
             method.name: Method(
                 method,
                 self.messages_map,
                 self.proto_file_name,
                 self.source_code_locations,
-                self.path
-                + (
-                    2,
-                    i,
-                ),
+                self.path + (2, i,),
             )
             for i, method in enumerate(self.service_pb.method)
         }
+        # fmt: on
 
     @property
     def host(self) -> Optional[str]:
@@ -546,7 +534,7 @@ class Service:
 
     @property
     def source_code_line(self):
-        """Return the start line number of source code in the proto file. This is zero-based."""
+        """Return the start line number of source code in the proto file."""
         location = self.source_code_locations[self.path]
         return location.span[0] + 1
 
@@ -579,6 +567,7 @@ class FileSet:
             for resource in fd.options.Extensions[resource_pb2.resource_definition]:
                 self.resources_database.register_resource(resource)
             # FileDescriptorProto.message_type has field number 4
+            # fmt: off
             self.messages_map.update(
                 (
                     message.name,
@@ -586,11 +575,7 @@ class FileSet:
                         message,
                         fd.name,
                         source_code_locations,
-                        path
-                        + (
-                            4,
-                            i,
-                        ),
+                        path + (4, i,),
                         self.resources_database,
                     ),
                 )
@@ -605,11 +590,7 @@ class FileSet:
                         self.messages_map,
                         fd.name,
                         source_code_locations,
-                        path
-                        + (
-                            6,
-                            i,
-                        ),
+                        path + (6, i,),
                     ),
                 )
                 for i, service in enumerate(fd.service)
@@ -622,15 +603,12 @@ class FileSet:
                         enum,
                         fd.name,
                         source_code_locations,
-                        path
-                        + (
-                            5,
-                            i,
-                        ),
+                        path + (5, i,),
                     ),
                 )
                 for i, enum in enumerate(fd.enum_type)
             )
+            # fmt: on
 
     def _get_packaging_options_map(self, file_options: descriptor_pb2.FileOptions):
         # TODO(xiaozhenliu): check with One-platform about the version naming.

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -38,8 +38,12 @@ class EnumComparatorTest(unittest.TestCase):
     def setUp(self):
         # We take the enumDescriptorProto `phoneType` and `phoneType` from the original
         # and updated `_descriptor_set.pb` files for comparison.
-        self.enum_original = FileSet(self._PB_ORIGNAL).messages_map["Person"].nested_enums["PhoneType"]
-        self.enum_update = FileSet(self._PB_UPDATE).messages_map["Person"].nested_enums["PhoneType"]
+        self.enum_original = (
+            FileSet(self._PB_ORIGNAL).messages_map["Person"].nested_enums["PhoneType"]
+        )
+        self.enum_update = (
+            FileSet(self._PB_UPDATE).messages_map["Person"].nested_enums["PhoneType"]
+        )
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -16,7 +16,7 @@ import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.enum_comparator import EnumComparator
 from src.findings.finding_container import FindingContainer
-from src.comparator.wrappers import Enum
+from src.comparator.wrappers import FileSet
 
 
 class EnumComparatorTest(unittest.TestCase):
@@ -36,10 +36,10 @@ class EnumComparatorTest(unittest.TestCase):
     _PB_UPDATE = _INVOKER_UPDATE.run()
 
     def setUp(self):
-        # We take the enumDescriptorProto `phoneType` and `phoneTypeUpdate` from the original
+        # We take the enumDescriptorProto `phoneType` and `phoneType` from the original
         # and updated `_descriptor_set.pb` files for comparison.
-        self.enum_original = Enum(self._PB_ORIGNAL.file[0].message_type[0].enum_type[0])
-        self.enum_update = Enum(self._PB_UPDATE.file[0].message_type[0].enum_type[0])
+        self.enum_original = FileSet(self._PB_ORIGNAL).messages_map["Person"].nested_enums["PhoneType"]
+        self.enum_update = FileSet(self._PB_UPDATE).messages_map["Person"].nested_enums["PhoneType"]
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -16,7 +16,7 @@ import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.enum_value_comparator import EnumValueComparator
 from src.findings.finding_container import FindingContainer
-from src.comparator.wrappers import EnumValue
+from src.comparator.wrappers import FileSet
 
 
 class EnumValueComparatorTest(unittest.TestCase):
@@ -33,9 +33,9 @@ class EnumValueComparatorTest(unittest.TestCase):
 
     def setUp(self):
         # Get `MOBILE` and `HOME` enumValueDescriptorProto from `message_v1_descriptor_set.pb`.
-        enum_type_values = self._PB_ORIGNAL.file[0].message_type[0].enum_type[0].value
-        self.enumValue_mobile = EnumValue(enum_type_values[0])
-        self.enumValue_home = EnumValue(enum_type_values[1])
+        enum_type_values = FileSet(self._PB_ORIGNAL).messages_map["Person"].nested_enums["PhoneType"].values
+        self.enumValue_mobile = enum_type_values[0]
+        self.enumValue_home = enum_type_values[1]
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -33,7 +33,12 @@ class EnumValueComparatorTest(unittest.TestCase):
 
     def setUp(self):
         # Get `MOBILE` and `HOME` enumValueDescriptorProto from `message_v1_descriptor_set.pb`.
-        enum_type_values = FileSet(self._PB_ORIGNAL).messages_map["Person"].nested_enums["PhoneType"].values
+        enum_type_values = (
+            FileSet(self._PB_ORIGNAL)
+            .messages_map["Person"]
+            .nested_enums["PhoneType"]
+            .values
+        )
         self.enumValue_mobile = enum_type_values[0]
         self.enumValue_home = enum_type_values[1]
 

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -15,7 +15,7 @@
 import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.field_comparator import FieldComparator
-from src.comparator.wrappers import Field
+from src.comparator.wrappers import FileSet
 from src.findings.finding_container import FindingContainer
 
 
@@ -35,19 +35,30 @@ class FieldComparatorTest(unittest.TestCase):
     _PB_ORIGNAL = _INVOKER_ORIGNAL.run()
     _PB_UPDATE = _INVOKER_UPDATE.run()
 
+    def setUp(self):
+        person_fields_v1 = FileSet(self._PB_ORIGNAL).messages_map["Person"].fields
+        person_fields_v1beta1 = FileSet(self._PB_UPDATE).messages_map["Person"].fields
+        self.name_field_v1 = person_fields_v1[1]
+        self.id_field_v1 = person_fields_v1[2]
+        self.id_field_v1beta1 = person_fields_v1beta1[2]
+        self.email_field_v1 = person_fields_v1[3]
+        self.email_field_v1beta1 = person_fields_v1beta1[3]
+        self.phones_field_v1 = person_fields_v1[4]
+        self.phones_field_v1beta1 = person_fields_v1beta1[4]
+        self.single_field_v1 = person_fields_v1[5]
+        self.single_field_v1beta1 = person_fields_v1beta1[5]
+
     def tearDown(self):
         FindingContainer.reset()
 
     def test_field_removal(self):
-        name_field = self._PB_ORIGNAL.file[0].message_type[0].field[0]
-        FieldComparator(Field(name_field), None).compare()
+        FieldComparator(self.name_field_v1, None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A Field name is removed")
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
 
     def test_field_addition(self):
-        name_field = self._PB_ORIGNAL.file[0].message_type[0].field[0]
-        FieldComparator(None, Field(name_field)).compare()
+        FieldComparator(None, self.name_field_v1).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Field name is added.")
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
@@ -55,9 +66,7 @@ class FieldComparatorTest(unittest.TestCase):
     def test_type_change(self):
         # Field `id` is `int32` type in `message_v1.proto`,
         # but updated to `string` in `message_v1beta1.proto`.
-        field_id_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[1])
-        field_id_update = Field(self._PB_UPDATE.file[0].message_type[0].field[1])
-        FieldComparator(field_id_original, field_id_update).compare()
+        FieldComparator(self.id_field_v1, self.id_field_v1beta1).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,
@@ -69,9 +78,7 @@ class FieldComparatorTest(unittest.TestCase):
     def test_repeated_label_change(self):
         # Field `phones` in `message_v1.proto` has `repeated` label,
         # but it's removed in the `message_v1beta1.proto`.
-        field_phones_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[3])
-        field_phones_update = Field(self._PB_UPDATE.file[0].message_type[0].field[3])
-        FieldComparator(field_phones_original, field_phones_update).compare()
+        FieldComparator(self.phones_field_v1, self.phones_field_v1beta1).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,
@@ -83,9 +90,7 @@ class FieldComparatorTest(unittest.TestCase):
     def test_name_change(self):
         # Field `email = 3` in `message_v1.proto` is renamed to
         # `email_address = 3` in the `message_v1beta1.proto`.
-        field_email_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[2])
-        field_email_update = Field(self._PB_UPDATE.file[0].message_type[0].field[2])
-        FieldComparator(field_email_original, field_email_update).compare()
+        FieldComparator(self.email_field_v1, self.email_field_v1beta1).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,
@@ -95,9 +100,7 @@ class FieldComparatorTest(unittest.TestCase):
 
     def test_oneof_change(self):
         # Field `single = 5` in `message_v1.proto` is moved out of One-of.
-        field_single_original = Field(self._PB_ORIGNAL.file[0].message_type[0].field[4])
-        field_single_update = Field(self._PB_UPDATE.file[0].message_type[0].field[4])
-        FieldComparator(field_single_original, field_single_update).compare()
+        FieldComparator(self.single_field_v1, self.single_field_v1beta1).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -36,29 +36,22 @@ class FieldComparatorTest(unittest.TestCase):
     _PB_UPDATE = _INVOKER_UPDATE.run()
 
     def setUp(self):
-        person_fields_v1 = FileSet(self._PB_ORIGNAL).messages_map["Person"].fields
-        person_fields_v1beta1 = FileSet(self._PB_UPDATE).messages_map["Person"].fields
-        self.name_field_v1 = person_fields_v1[1]
-        self.id_field_v1 = person_fields_v1[2]
-        self.id_field_v1beta1 = person_fields_v1beta1[2]
-        self.email_field_v1 = person_fields_v1[3]
-        self.email_field_v1beta1 = person_fields_v1beta1[3]
-        self.phones_field_v1 = person_fields_v1[4]
-        self.phones_field_v1beta1 = person_fields_v1beta1[4]
-        self.single_field_v1 = person_fields_v1[5]
-        self.single_field_v1beta1 = person_fields_v1beta1[5]
+        self.person_fields_v1 = FileSet(self._PB_ORIGNAL).messages_map["Person"].fields
+        self.person_fields_v1beta1 = (
+            FileSet(self._PB_UPDATE).messages_map["Person"].fields
+        )
 
     def tearDown(self):
         FindingContainer.reset()
 
     def test_field_removal(self):
-        FieldComparator(self.name_field_v1, None).compare()
+        FieldComparator(self.person_fields_v1[1], None).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A Field name is removed")
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
 
     def test_field_addition(self):
-        FieldComparator(None, self.name_field_v1).compare()
+        FieldComparator(None, self.person_fields_v1[1]).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Field name is added.")
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
@@ -66,7 +59,9 @@ class FieldComparatorTest(unittest.TestCase):
     def test_type_change(self):
         # Field `id` is `int32` type in `message_v1.proto`,
         # but updated to `string` in `message_v1beta1.proto`.
-        FieldComparator(self.id_field_v1, self.id_field_v1beta1).compare()
+        FieldComparator(
+            self.person_fields_v1[2], self.person_fields_v1beta1[2]
+        ).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,
@@ -78,7 +73,9 @@ class FieldComparatorTest(unittest.TestCase):
     def test_repeated_label_change(self):
         # Field `phones` in `message_v1.proto` has `repeated` label,
         # but it's removed in the `message_v1beta1.proto`.
-        FieldComparator(self.phones_field_v1, self.phones_field_v1beta1).compare()
+        FieldComparator(
+            self.person_fields_v1[4], self.person_fields_v1beta1[4]
+        ).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,
@@ -90,7 +87,9 @@ class FieldComparatorTest(unittest.TestCase):
     def test_name_change(self):
         # Field `email = 3` in `message_v1.proto` is renamed to
         # `email_address = 3` in the `message_v1beta1.proto`.
-        FieldComparator(self.email_field_v1, self.email_field_v1beta1).compare()
+        FieldComparator(
+            self.person_fields_v1[3], self.person_fields_v1beta1[3]
+        ).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,
@@ -100,7 +99,9 @@ class FieldComparatorTest(unittest.TestCase):
 
     def test_oneof_change(self):
         # Field `single = 5` in `message_v1.proto` is moved out of One-of.
-        FieldComparator(self.single_field_v1, self.single_field_v1beta1).compare()
+        FieldComparator(
+            self.person_fields_v1[5], self.person_fields_v1beta1[5]
+        ).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(
             finding.message,

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -15,7 +15,7 @@
 import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.message_comparator import DescriptorComparator
-from src.comparator.wrappers import Message
+from src.comparator.wrappers import FileSet
 from src.findings.finding_container import FindingContainer
 
 
@@ -38,10 +38,10 @@ class DescriptorComparatorTest(unittest.TestCase):
     def setUp(self):
         # Get `Person` and `AddressBook` DescriptoProto from the
         # original and updated `*_descriptor_set.pb` files.
-        self.person_msg = Message(self._PB_ORIGNAL.file[0].message_type[0])
-        self.person_msg_update = Message(self._PB_UPDATE.file[0].message_type[0])
-        self.addressBook_msg = Message(self._PB_ORIGNAL.file[0].message_type[1])
-        self.addressBook_msg_update = Message(self._PB_UPDATE.file[0].message_type[1])
+        self.person_msg = FileSet(self._PB_ORIGNAL).messages_map["Person"]
+        self.person_msg_update = FileSet(self._PB_UPDATE).messages_map["Person"]
+        self.addressBook_msg = FileSet(self._PB_ORIGNAL).messages_map["AddressBook"]
+        self.addressBook_msg_update = FileSet(self._PB_UPDATE).messages_map["AddressBook"]
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -41,7 +41,9 @@ class DescriptorComparatorTest(unittest.TestCase):
         self.person_msg = FileSet(self._PB_ORIGNAL).messages_map["Person"]
         self.person_msg_update = FileSet(self._PB_UPDATE).messages_map["Person"]
         self.addressBook_msg = FileSet(self._PB_ORIGNAL).messages_map["AddressBook"]
-        self.addressBook_msg_update = FileSet(self._PB_UPDATE).messages_map["AddressBook"]
+        self.addressBook_msg_update = FileSet(self._PB_UPDATE).messages_map[
+            "AddressBook"
+        ]
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_service_comparator.py
+++ b/test/comparator/test_service_comparator.py
@@ -1,8 +1,7 @@
 import unittest
 from test.tools.invoker import UnittestInvoker
 from src.comparator.service_comparator import ServiceComparator
-from src.comparator.wrappers import Service
-from src.comparator.wrappers import Message
+from src.comparator.wrappers import FileSet
 from src.findings.finding_container import FindingContainer
 
 
@@ -30,38 +29,11 @@ class DescriptorComparatorTest(unittest.TestCase):
 
     def setUp(self):
         # Get `Example` service from the original and updated `service_*.proto` files.
-        service_v1_pb = self._INVOKER_SERVICE_ORIGNAL.run()
-        service_v1beta1_pb = self._INVOKER_SERVICE_UPDATE.run()
-        self.messages_map_original = {
-            m.name: Message(m) for m in service_v1_pb.file[0].message_type
-        }
-        self.messages_map_update = {
-            m.name: Message(m) for m in service_v1beta1_pb.file[0].message_type
-        }
-        self.service_original = Service(
-            service_v1_pb.file[0].service[0], self.messages_map_original
-        )
-        self.service_update = Service(
-            service_v1beta1_pb.file[0].service[0], self.messages_map_update
-        )
+        self.service_original = FileSet(self._INVOKER_SERVICE_ORIGNAL.run()).services_map["Example"]
+        self.service_update = FileSet(self._INVOKER_SERVICE_UPDATE.run()).services_map["Example"]
         # Get `Example` service from the original and updated `service_annotation_*.proto` files.
-        service_annotation_v1_pb = self._INVOKER_ANNOTATION_ORIGNAL.run()
-        service_annotation_v1beta1_pb = self._INVOKER_ANNOTATION_UPDATE.run()
-        self.annotation_messages_map_original = {
-            m.name: Message(m) for m in service_annotation_v1_pb.file[0].message_type
-        }
-        self.annotation_messages_map_update = {
-            m.name: Message(m)
-            for m in service_annotation_v1beta1_pb.file[0].message_type
-        }
-        self.service_annotation_original = Service(
-            service_annotation_v1_pb.file[0].service[0],
-            self.annotation_messages_map_original,
-        )
-        self.service_annotation_update = Service(
-            service_annotation_v1beta1_pb.file[0].service[0],
-            self.annotation_messages_map_update,
-        )
+        self.service_annotation_original = FileSet(self._INVOKER_ANNOTATION_ORIGNAL.run()).services_map["Example"]
+        self.service_annotation_update = FileSet(self._INVOKER_ANNOTATION_UPDATE.run()).services_map["Example"]
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_service_comparator.py
+++ b/test/comparator/test_service_comparator.py
@@ -29,11 +29,19 @@ class DescriptorComparatorTest(unittest.TestCase):
 
     def setUp(self):
         # Get `Example` service from the original and updated `service_*.proto` files.
-        self.service_original = FileSet(self._INVOKER_SERVICE_ORIGNAL.run()).services_map["Example"]
-        self.service_update = FileSet(self._INVOKER_SERVICE_UPDATE.run()).services_map["Example"]
+        self.service_original = FileSet(
+            self._INVOKER_SERVICE_ORIGNAL.run()
+        ).services_map["Example"]
+        self.service_update = FileSet(self._INVOKER_SERVICE_UPDATE.run()).services_map[
+            "Example"
+        ]
         # Get `Example` service from the original and updated `service_annotation_*.proto` files.
-        self.service_annotation_original = FileSet(self._INVOKER_ANNOTATION_ORIGNAL.run()).services_map["Example"]
-        self.service_annotation_update = FileSet(self._INVOKER_ANNOTATION_UPDATE.run()).services_map["Example"]
+        self.service_annotation_original = FileSet(
+            self._INVOKER_ANNOTATION_ORIGNAL.run()
+        ).services_map["Example"]
+        self.service_annotation_update = FileSet(
+            self._INVOKER_ANNOTATION_UPDATE.run()
+        ).services_map["Example"]
 
     def tearDown(self):
         FindingContainer.reset()

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -48,6 +48,8 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(foo_method.paged_result_field, None)
         self.assertEqual(foo_method.method_signatures, ["content", "error"])
         self.assertEqual(foo_method.http_annotation["http_uri"], "/v1/example:foo")
+        self.assertEqual(foo_method.proto_file_name, "wrappers.proto")
+
         # Method `Foo` is defined at Line21 in .proto file.
         self.assertEqual(foo_method.source_code_line, 21)
 
@@ -67,6 +69,7 @@ class WrappersTest(unittest.TestCase):
         # Message `FooRequest` is defined at Line41 in .proto file.
         self.assertEqual(foo_request_message.source_code_line, 41)
         self.assertTrue(foo_request_message.nested_messages["NestedMessage"])
+        self.assertEqual(foo_request_message.proto_file_name, "wrappers.proto")
         # Nested message `NestedMessage` is defined at Line50 in .proto file.
         self.assertEqual(
             foo_request_message.nested_messages["NestedMessage"].source_code_line, 50
@@ -98,6 +101,7 @@ class WrappersTest(unittest.TestCase):
         )
         # Enum `enum_field` is defined at Line57 in .proto file.
         self.assertEqual(enum_field.source_code_line, 57)
+        self.assertEqual(enum_field.proto_file_name, "wrappers.proto")
 
     def test_enum_wrapper(self):
         enum = self._FILE_SET.enums_map["Enum1"]
@@ -106,6 +110,7 @@ class WrappersTest(unittest.TestCase):
         # EnumValue `a` and `b` are defined at Line57 in .proto file.
         self.assertEqual(enum.values[0].source_code_line, 65)
         self.assertEqual(enum.values[1].source_code_line, 66)
+        self.assertEqual(enum.values[0].proto_file_name, "wrappers.proto")
 
     @classmethod
     def tearDownClass(cls):

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -40,6 +40,7 @@ class WrappersTest(unittest.TestCase):
         service = self._FILE_SET.services_map["Example"]
         # Service `Example` is defined at Line19 in .proto file.
         self.assertEqual(service.source_code_line, 19)
+        self.assertEqual(service.proto_file_name, "wrappers.proto")
         foo_method = service.methods["Foo"]
         bar_method = service.methods["Bar"]
         self.assertEqual(foo_method.input, "FooRequest")

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -48,10 +48,10 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(foo_method.paged_result_field, None)
         self.assertEqual(foo_method.method_signatures, ["content", "error"])
         self.assertEqual(foo_method.http_annotation["http_uri"], "/v1/example:foo")
-        self.assertEqual(foo_method.proto_file_name, "wrappers.proto")
 
         # Method `Foo` is defined at Line21 in .proto file.
         self.assertEqual(foo_method.source_code_line, 21)
+        self.assertEqual(foo_method.proto_file_name, "wrappers.proto")
 
         self.assertEqual(bar_method.input, "FooRequest")
         self.assertEqual(bar_method.output, ".google.longrunning.Operation")

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -38,6 +38,8 @@ class WrappersTest(unittest.TestCase):
 
     def test_service_wrapper(self):
         service = self._FILE_SET.services_map["Example"]
+        # Service `Example` is defined at Line19 in .proto file.
+        self.assertEqual(service.source_code_line, 19)
         foo_method = service.methods["Foo"]
         bar_method = service.methods["Bar"]
         self.assertEqual(foo_method.input, "FooRequest")
@@ -45,6 +47,8 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(foo_method.paged_result_field, None)
         self.assertEqual(foo_method.method_signatures, ["content", "error"])
         self.assertEqual(foo_method.http_annotation["http_uri"], "/v1/example:foo")
+        # Method `Foo` is defined at Line21 in .proto file.
+        self.assertEqual(foo_method.source_code_line, 21)
 
         self.assertEqual(bar_method.input, "FooRequest")
         self.assertEqual(bar_method.output, ".google.longrunning.Operation")
@@ -53,15 +57,30 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(bar_method.lro_annotation["response_type"], "FooResponse")
         self.assertEqual(bar_method.lro_annotation["metadata_type"], "FooMetadata")
         self.assertEqual(bar_method.http_annotation["http_uri"], "/v1/example:bar")
+        # Method `Bar` is defined at Line29 in .proto file.
+        self.assertEqual(bar_method.source_code_line, 29)
 
     def test_message_wrapper(self):
         messages_map = self._FILE_SET.messages_map
         foo_request_message = messages_map["FooRequest"]
-        resource = foo_request_message.resource
+        # Message `FooRequest` is defined at Line41 in .proto file.
+        self.assertEqual(foo_request_message.source_code_line, 41)
         self.assertTrue(foo_request_message.nested_messages["NestedMessage"])
+        # Nested message `NestedMessage` is defined at Line50 in .proto file.
+        self.assertEqual(
+            foo_request_message.nested_messages["NestedMessage"].source_code_line, 50
+        )
         self.assertTrue(foo_request_message.nested_enums["NestedEnum"])
+        # Nested enum `NestedEnum` is defined at Line51 in .proto file.
+        self.assertEqual(
+            foo_request_message.nested_enums["NestedEnum"].source_code_line, 51
+        )
         self.assertEqual(foo_request_message.oneof_fields[0].name, "content")
         self.assertEqual(foo_request_message.oneof_fields[1].name, "error")
+        # Oneof field `content` and `error` are defined at Line47,48 in .proto file.
+        self.assertEqual(foo_request_message.oneof_fields[0].source_code_line, 47)
+        self.assertEqual(foo_request_message.oneof_fields[1].source_code_line, 48)
+        resource = foo_request_message.resource
         self.assertEqual(resource.pattern, ["foo/{foo}/bar/{bar}"])
         self.assertEqual(resource.type, "example.googleapis.com/Foo")
 
@@ -76,11 +95,16 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(
             enum_field.resource_reference.child_type, "example.googleapis.com/t1"
         )
+        # Enum `enum_field` is defined at Line57 in .proto file.
+        self.assertEqual(enum_field.source_code_line, 57)
 
     def test_enum_wrapper(self):
         enum = self._FILE_SET.enums_map["Enum1"]
         self.assertEqual(enum.values[0].name, "a")
         self.assertEqual(enum.values[1].name, "b")
+        # EnumValue `a` and `b` are defined at Line57 in .proto file.
+        self.assertEqual(enum.values[0].source_code_line, 65)
+        self.assertEqual(enum.values[1].source_code_line, 66)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/tools/invoker.py
+++ b/test/tools/invoker.py
@@ -46,6 +46,7 @@ class UnittestInvoker:
             protoc_command.append(f"--proto_path={self._PROTOBUF_PROTOS_DIR}")
         descriptor_set_output = os.path.join(self._PROTOS_DIR, self.descriptor_set_file)
         protoc_command.append(f"-o{descriptor_set_output}")
+        protoc_command.append("--include_source_info")
         protoc_command.extend(
             os.path.join(self._PROTOS_DIR, pf) for pf in self.proto_files
         )


### PR DESCRIPTION
1. Add source_code_line property for each classes, so that we can call for example  `methodA.source_code_line` to get the source code line number of this method. (will only return the **start** line number)
2. unit tests.

TODO(xiaozhenliu): parse SourceCode location for properties in each descriptor.
For example: during comparison, we will need the source code line number for method.input.
The annotations cannot precisely located, because they are customized options, and we use field number to get the location. For extension options, they share the same path [..., 1000].