### PR TITLE
feat[1/6]: add location information of findings in enum comparator

### DIFF
--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -27,19 +27,31 @@ class EnumComparator:
         # 1. If original EnumDescriptor is None, then a new
         # EnumDescriptor is added.
         if self.enum_original is None:
-            msg = f"A new Enum {self.enum_update.name} is added."
-            FindingContainer.addFinding(FindingCategory.ENUM_ADDITION, "", msg, False)
+            FindingContainer.addFinding(
+                category=FindingCategory.ENUM_ADDITION,
+                location=f"{self.enum_update.proto_file_name} Line: {self.enum_update.source_code_line}",
+                message=f"A new Enum {self.enum_update.name} is added.",
+                actionable=False,
+            )
 
         # 2. If updated EnumDescriptor is None, then the original
         # EnumDescriptor is removed.
         elif self.enum_update is None:
-            msg = f"An Enum {self.enum_original.name} is removed"
-            FindingContainer.addFinding(FindingCategory.ENUM_REMOVAL, "", msg, True)
+            FindingContainer.addFinding(
+                category=FindingCategory.ENUM_REMOVAL,
+                location=f"{self.enum_original.proto_file_name} Line: {self.enum_original.source_code_line}",
+                message=f"An Enum {self.enum_original.name} is removed",
+                actionable=True,
+            )
 
         # 3. If both EnumDescriptors are existing, check if the name is changed.
         elif self.enum_original.name != self.enum_update.name:
-            msg = f"Name of the Enum is changed, the original is {self.enum_original.name}, but the updated is {self.enum_update.name}"
-            FindingContainer.addFinding(FindingCategory.ENUM_NAME_CHANGE, "", msg, True)
+            FindingContainer.addFinding(
+                category=FindingCategory.ENUM_NAME_CHANGE,
+                location=f"{self.enum_update.proto_file_name} Line: {self.enum_update.source_code_line}",
+                message=f"Name of the Enum is changed, the original is {self.enum_original.name}, but the updated is {self.enum_update.name}",
+                actionable=True,
+            )
 
         # 4. If the EnumDescriptors have the same name, check the values
         # of them stay the same. Enum values are identified by number,

--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -44,16 +44,7 @@ class EnumComparator:
                 actionable=True,
             )
 
-        # 3. If both EnumDescriptors are existing, check if the name is changed.
-        elif self.enum_original.name != self.enum_update.name:
-            FindingContainer.addFinding(
-                category=FindingCategory.ENUM_NAME_CHANGE,
-                location=f"{self.enum_update.proto_file_name} Line: {self.enum_update.source_code_line}",
-                message=f"Name of the Enum is changed, the original is {self.enum_original.name}, but the updated is {self.enum_update.name}",
-                actionable=True,
-            )
-
-        # 4. If the EnumDescriptors have the same name, check the values
+        # 3. If the EnumDescriptors have the same name, check the values
         # of them stay the same. Enum values are identified by number,
         # not by name.
         else:

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -62,12 +62,6 @@ class EnumComparatorTest(unittest.TestCase):
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
         self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 10")
 
-    def test_enum_value_change(self):
-        EnumComparator(self.enum_original, self.enum_update).compare()
-        finding = FindingContainer.getAllFindings()[0]
-        self.assertEqual(finding.message, "A new EnumValue SCHOOL is added.")
-        self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
-
     def test_no_api_change(self):
         EnumComparator(self.enum_update, self.enum_update).compare()
         self.assertEqual(len(FindingContainer.getAllFindings()), 0)

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -62,6 +62,12 @@ class EnumComparatorTest(unittest.TestCase):
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
         self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 10")
 
+    def test_enum_value_change(self):
+        EnumComparator(self.enum_original, self.enum_update).compare()
+        finding = FindingContainer.getAllFindings()[0]
+        self.assertEqual(finding.message, "A new EnumValue SCHOOL is added.")
+        self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
+
     def test_no_api_change(self):
         EnumComparator(self.enum_update, self.enum_update).compare()
         self.assertEqual(len(FindingContainer.getAllFindings()), 0)

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -53,12 +53,14 @@ class EnumComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "An Enum PhoneType is removed")
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
+        self.assertEqual(finding.location.path, "message_v1.proto Line: 10")
 
     def test_enum_addition(self):
         EnumComparator(None, self.enum_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Enum PhoneType is added.")
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
+        self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 10")
 
     def test_enum_value_change(self):
         EnumComparator(self.enum_original, self.enum_update).compare()


### PR DESCRIPTION
1. Add location information for each finding in `enum` comparator, updated the unit tests for verification.
2. Removed the name change check, since the `enum` is identified by name, the comparator will always compare enums with the same name. And the name change is acting like one enum is removed and another one is added. This can be detected by the two findings at the same location, but one is enum removal another one is enum addition (should be handled when printing out the findings messages).