### PR TITLE
refactor!: location of findings has attributes proto_file_name and source_code_line

### DIFF
--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -29,7 +29,8 @@ class EnumComparator:
         if self.enum_original is None:
             FindingContainer.addFinding(
                 category=FindingCategory.ENUM_ADDITION,
-                location=f"{self.enum_update.proto_file_name} Line: {self.enum_update.source_code_line}",
+                proto_file_name=self.enum_update.proto_file_name,
+                source_code_line=self.enum_update.source_code_line,
                 message=f"A new Enum {self.enum_update.name} is added.",
                 actionable=False,
             )
@@ -39,7 +40,8 @@ class EnumComparator:
         elif self.enum_update is None:
             FindingContainer.addFinding(
                 category=FindingCategory.ENUM_REMOVAL,
-                location=f"{self.enum_original.proto_file_name} Line: {self.enum_original.source_code_line}",
+                proto_file_name=self.enum_original.proto_file_name,
+                source_code_line=self.enum_original.source_code_line,
                 message=f"An Enum {self.enum_original.name} is removed",
                 actionable=True,
             )

--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -31,7 +31,8 @@ class EnumValueComparator:
         if self.enum_value_original is None:
             FindingContainer.addFinding(
                 category=FindingCategory.ENUM_VALUE_ADDITION,
-                location=f"{self.enum_value_update.proto_file_name} Line: {self.enum_value_update.source_code_line}",
+                proto_file_name=self.enum_value_update.proto_file_name,
+                source_code_line=self.enum_value_update.source_code_line,
                 message=f"A new EnumValue {self.enum_value_update.name} is added.",
                 actionable=False,
             )
@@ -39,7 +40,8 @@ class EnumValueComparator:
         elif self.enum_value_update is None:
             FindingContainer.addFinding(
                 category=FindingCategory.ENUM_VALUE_REMOVAL,
-                location=f"{self.enum_value_original.proto_file_name} Line: {self.enum_value_original.source_code_line}",
+                proto_file_name=self.enum_value_original.proto_file_name,
+                source_code_line=self.enum_value_original.source_code_line,
                 message=f"An EnumValue {self.enum_value_original.name} is removed",
                 actionable=True,
             )
@@ -47,7 +49,8 @@ class EnumValueComparator:
         elif self.enum_value_original.name != self.enum_value_update.name:
             FindingContainer.addFinding(
                 category=FindingCategory.ENUM_VALUE_NAME_CHANGE,
-                location=f"{self.enum_value_update.proto_file_name} Line: {self.enum_value_update.source_code_line}",
+                proto_file_name=self.enum_value_update.proto_file_name,
+                source_code_line=self.enum_value_update.source_code_line,
                 message=f"Name of the EnumValue is changed, the original is {self.enum_value_original.name}, but the updated is {self.enum_value_update.name}",
                 actionable=True,
             )

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -38,7 +38,8 @@ class FieldComparator:
         if self.field_original is None:
             FindingContainer.addFinding(
                 category=FindingCategory.FIELD_ADDITION,
-                location=f"{self.field_update.proto_file_name} Line: {self.field_update.source_code_line}",
+                proto_file_name=self.field_update.proto_file_name,
+                source_code_line=self.field_update.source_code_line,
                 message=f"A new Field {self.field_update.name} is added.",
                 actionable=False,
             )
@@ -49,7 +50,8 @@ class FieldComparator:
         if self.field_update is None:
             FindingContainer.addFinding(
                 category=FindingCategory.FIELD_REMOVAL,
-                location=f"{self.field_original.proto_file_name} Line: {self.field_original.source_code_line}",
+                proto_file_name=self.field_original.proto_file_name,
+                source_code_line=self.field_original.source_code_line,
                 message=f"A Field {self.field_original.name} is removed",
                 actionable=True,
             )
@@ -65,7 +67,8 @@ class FieldComparator:
         if self.field_original.name != self.field_update.name:
             FindingContainer.addFinding(
                 category=FindingCategory.FIELD_NAME_CHANGE,
-                location=f"{self.field_update.proto_file_name} Line: {self.field_update.source_code_line}",
+                proto_file_name=self.field_update.proto_file_name,
+                source_code_line=self.field_update.source_code_line,
                 message=f"Name of the Field is changed, the original is {self.field_original.name}, but the updated is {self.field_update.name}",
                 actionable=True,
             )
@@ -77,7 +80,8 @@ class FieldComparator:
         if self.field_original.label != self.field_update.label:
             FindingContainer.addFinding(
                 category=FindingCategory.FIELD_REPEATED_CHANGE,
-                location="",
+                proto_file_name="",
+                source_code_line=0,
                 message=f"Repeated state of the Field is changed, the original is {self.field_original.label}, but the updated is {self.field_update.label}",
                 actionable=True,
             )
@@ -88,18 +92,21 @@ class FieldComparator:
         if self.field_original.proto_type != self.field_update.proto_type:
             FindingContainer.addFinding(
                 category=FindingCategory.FIELD_TYPE_CHANGE,
-                location="",
+                proto_file_name="",
+                source_code_line=0,
                 message=f"Type of the field is changed, the original is {self.field_original.proto_type}, but the updated is {self.field_update.proto_type}",
                 actionable=True,
             )
         # 6. Check the oneof_index of the field.
         if self.field_original.oneof != self.field_update.oneof:
-            location = f"{self.field_update.proto_file_name} Line: {self.field_update.source_code_line}"
+            proto_file_name = self.field_update.proto_file_name
+            source_code_line = self.field_update.source_code_line
             if self.field_original.oneof:
                 msg = f"The existing field {self.field_original.name} is moved out of One-of."
                 FindingContainer.addFinding(
                     category=FindingCategory.FIELD_ONEOF_REMOVAL,
-                    location=location,
+                    proto_file_name=proto_file_name,
+                    source_code_line=source_code_line,
                     message=msg,
                     actionable=True,
                 )
@@ -107,7 +114,8 @@ class FieldComparator:
                 msg = f"The existing field {self.field_original.name} is moved into One-of."
                 FindingContainer.addFinding(
                     category=FindingCategory.FIELD_ONEOF_ADDITION,
-                    location=location,
+                    proto_file_name=proto_file_name,
+                    source_code_line=source_code_line,
                     message=msg,
                     actionable=True,
                 )
@@ -125,20 +133,22 @@ class FieldComparator:
         # A `google.api.resource_reference` annotation is added.
         if not resource_ref_original and resource_ref_update:
             FindingContainer.addFinding(
-                FindingCategory.RESOURCE_REFERENCE_ADDITION,
-                "",
-                f"A resource reference option is added to the field {field_original.name}",
-                False,
+                category=FindingCategory.RESOURCE_REFERENCE_ADDITION,
+                proto_file_name="",
+                source_code_line=0,
+                message=f"A resource reference option is added to the field {field_original.name}",
+                actionable=False,
             )
             return
         # Resource annotation is removed, check if it is added as a message resource.
         if resource_ref_original and not resource_ref_update:
             if not self._resource_ref_in_local(resource_ref_original):
                 FindingContainer.addFinding(
-                    FindingCategory.RESOURCE_REFERENCE_REMOVAL,
-                    "",
-                    f"A resource reference option of field '{field_original.name}' is removed.",
-                    True,
+                    category=FindingCategory.RESOURCE_REFERENCE_REMOVAL,
+                    proto_file_name="",
+                    source_code_line=0,
+                    message=f"A resource reference option of field '{field_original.name}' is removed.",
+                    actionable=True,
                 )
             return
         # Resource annotation is both existing in the field for original and update versions.
@@ -150,10 +160,11 @@ class FieldComparator:
             update_type = resource_ref_update.type or resource_ref_update.child_type
             if original_type != update_type:
                 FindingContainer.addFinding(
-                    FindingCategory.RESOURCE_REFERENCE_CHANGE,
-                    "",
-                    f"The type of resource reference option in field '{field_original.name}' is changed from '{original_type}' to '{update_type}'.",
-                    True,
+                    category=FindingCategory.RESOURCE_REFERENCE_CHANGE,
+                    proto_file_name="",
+                    source_code_line=0,
+                    message=f"The type of resource reference option in field '{field_original.name}' is changed from '{original_type}' to '{update_type}'.",
+                    actionabel=True,
                 )
             return
         # The `type` is changed to `child_type` or `child_type` is changed to `type`, but
@@ -205,10 +216,11 @@ class FieldComparator:
         if parent_type not in [parent.type for parent in parent_resources]:
             # Resulting referenced resource patterns cannot be resolved identical.
             FindingContainer.addFinding(
-                FindingCategory.RESOURCE_REFERENCE_CHANGE,
-                "",
-                f"The child_type '{child_type}' and type '{parent_type}' of "
+                category=FindingCategory.RESOURCE_REFERENCE_CHANGE,
+                proto_file_name="",
+                source_code_line=0,
+                message=f"The child_type '{child_type}' and type '{parent_type}' of "
                 f"resource reference option in field '{self.field_original.name}' "
                 "cannot be resolved to the identical resource.",
-                True,
+                actionable=True,
             )

--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -93,7 +93,8 @@ class FileSetComparator:
             if len(patterns_original) > len(patterns_update):
                 FindingContainer.addFinding(
                     category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
-                    location="",
+                    proto_file_name="",
+                    source_code_line=0,
                     message=f"An existing pattern value of the resource definition '{resource_type}' is removed.",
                     actionable=True,
                 )
@@ -103,7 +104,8 @@ class FileSetComparator:
                 if old_pattern != new_pattern:
                     FindingContainer.addFinding(
                         category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
-                        location="",
+                        proto_file_name="",
+                        source_code_line=0,
                         message=f"Pattern value of the resource definition '{resource_type}' is updated from '{old_pattern}' to '{new_pattern}'.",
                         actionable=True,
                     )
@@ -112,7 +114,8 @@ class FileSetComparator:
         for resource_type in resources_types_update - resources_types_original:
             FindingContainer.addFinding(
                 category=FindingCategory.RESOURCE_DEFINITION_ADDITION,
-                location="",
+                proto_file_name="",
+                source_code_line=0,
                 message=f"A file-level resource definition '{resource_type}' has been added.",
                 actionable=False,
             )

--- a/src/comparator/message_comparator.py
+++ b/src/comparator/message_comparator.py
@@ -37,7 +37,8 @@ class DescriptorComparator:
         if message_original is None:
             FindingContainer.addFinding(
                 category=FindingCategory.MESSAGE_ADDITION,
-                location=f"{message_update.proto_file_name} Line: {message_update.source_code_line}",
+                proto_file_name=message_update.proto_file_name,
+                source_code_line=message_update.source_code_line,
                 message=f"A new message {message_update.name} is added.",
                 actionable=False,
             )
@@ -46,7 +47,8 @@ class DescriptorComparator:
         if message_update is None:
             FindingContainer.addFinding(
                 category=FindingCategory.MESSAGE_REMOVAL,
-                location=f"{message_original.proto_file_name} Line: {message_original.source_code_line}",
+                proto_file_name=message_original.proto_file_name,
+                source_code_line=message_original.source_code_line,
                 message=f"A message {message_original.name} is removed",
                 actionable=True,
             )
@@ -137,7 +139,8 @@ class DescriptorComparator:
         if not resource_original and resource_update:
             FindingContainer.addFinding(
                 category=FindingCategory.RESOURCE_DEFINITION_ADDITION,
-                location="",
+                proto_file_name="",
+                source_code_line=0,
                 message=f"A message-level resource definition {resource_update.type} has been added.",
                 actionable=False,
             )
@@ -152,7 +155,8 @@ class DescriptorComparator:
             if not self.global_resources_update:
                 FindingContainer.addFinding(
                     category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
-                    location="",
+                    proto_file_name="",
+                    source_code_line=0,
                     message=f"A message-level resource definition {resource_original.type} has been removed.",
                     actionable=True,
                 )
@@ -161,7 +165,8 @@ class DescriptorComparator:
             if resource_original.type not in self.global_resources_update.types:
                 FindingContainer.addFinding(
                     category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
-                    location="",
+                    proto_file_name="",
+                    source_code_line=0,
                     message=f"A message-level resource definition {resource_original.type} has been removed.",
                     actionable=True,
                 )
@@ -179,7 +184,8 @@ class DescriptorComparator:
                 ):
                     FindingContainer.addFinding(
                         category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
-                        location="",
+                        proto_file_name="",
+                        source_code_line=0,
                         message=f"A message-level resource definition {resource_original.type} has been removed.",
                         actionable=True,
                     )
@@ -191,7 +197,8 @@ class DescriptorComparator:
         ):
             FindingContainer.addFinding(
                 category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
-                location="",
+                proto_file_name="",
+                source_code_line=0,
                 message=f"The pattern of message-level resource definition has changed from {resource_original.pattern} to {resource_update.pattern}.",
                 actionable=True,
             )

--- a/src/comparator/service_comparator.py
+++ b/src/comparator/service_comparator.py
@@ -33,7 +33,8 @@ class ServiceComparator:
         if self.service_original is None:
             FindingContainer.addFinding(
                 category=FindingCategory.SERVICE_ADDITION,
-                location=f"{self.service_update.proto_file_name} Line: {self.service_update.source_code_line}",
+                proto_file_name=self.service_update.proto_file_name,
+                source_code_line=self.service_update.source_code_line,
                 message=f"A new service {self.service_update.name} is added.",
                 actionable=False,
             )
@@ -42,7 +43,8 @@ class ServiceComparator:
         if self.service_update is None:
             FindingContainer.addFinding(
                 category=FindingCategory.SERVICE_REMOVAL,
-                location=f"{self.service_original.proto_file_name} Line: {self.service_original.source_code_line}",
+                proto_file_name=self.service_original.proto_file_name,
+                source_code_line=self.service_original.source_code_line,
                 message=f"A service {self.service_original.name} is removed",
                 actionable=True,
             )
@@ -73,7 +75,8 @@ class ServiceComparator:
             removed_method = methods_original[name]
             FindingContainer.addFinding(
                 category=FindingCategory.METHOD_REMOVAL,
-                location=f"{removed_method.proto_file_name} Line: {removed_method.source_code_line}",
+                proto_file_name=removed_method.proto_file_name,
+                source_code_line=removed_method.source_code_line,
                 message=f"An rpc method {name} is removed",
                 actionable=True,
             )
@@ -82,7 +85,8 @@ class ServiceComparator:
             added_method = methods_update[name]
             FindingContainer.addFinding(
                 category=FindingCategory.METHOD_ADDTION,
-                location=f"{added_method.proto_file_name} Line: {added_method.source_code_line}",
+                proto_file_name=added_method.proto_file_name,
+                source_code_line=added_method.source_code_line,
                 message=f"An rpc method {name} is added",
                 actionable=False,
             )
@@ -95,7 +99,8 @@ class ServiceComparator:
             if input_type_original != input_type_update:
                 FindingContainer.addFinding(
                     category=FindingCategory.METHOD_INPUT_TYPE_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.input.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.input.source_code_line,
                     message=f"Input type of method {name} is changed from {input_type_original} to {input_type_update}",
                     actionable=True,
                 )
@@ -105,7 +110,8 @@ class ServiceComparator:
             if response_type_original != response_type_update:
                 FindingContainer.addFinding(
                     category=FindingCategory.METHOD_RESPONSE_TYPE_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.output.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.output.source_code_line,
                     message=f"Output type of method {name} is changed from {response_type_original} to {response_type_update}",
                     actionable=True,
                 )
@@ -116,7 +122,8 @@ class ServiceComparator:
             ):
                 FindingContainer.addFinding(
                     category=FindingCategory.METHOD_CLIENT_STREAMING_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.client_streaming.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.client_streaming.source_code_line,
                     message=f"The request streaming type of method {name} is changed",
                     actionable=True,
                 )
@@ -127,7 +134,8 @@ class ServiceComparator:
             ):
                 FindingContainer.addFinding(
                     category=FindingCategory.METHOD_SERVER_STREAMING_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.server_streaming.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.server_streaming.source_code_line,
                     message=f"The response streaming type of method {name} is changed",
                     actionable=True,
                 )
@@ -135,7 +143,8 @@ class ServiceComparator:
             if method_original.paged_result_field != method_update.paged_result_field:
                 FindingContainer.addFinding(
                     category=FindingCategory.METHOD_PAGINATED_RESPONSE_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.source_code_line,
                     message=f"The paginated response of method {name} is changed",
                     actionable=True,
                 )
@@ -163,14 +172,16 @@ class ServiceComparator:
             if http_annotation_original and not http_annotation_update:
                 FindingContainer.addFinding(
                     category=FindingCategory.HTTP_ANNOTATION_REMOVAL,
-                    location=f"{method_original.proto_file_name} Line: {method_original.http_annotation.source_code_line}",
+                    proto_file_name=method_original.proto_file_name,
+                    source_code_line=method_original.http_annotation.source_code_line,
                     message="A google.api.http annotation is removed.",
                     actionable=True,
                 )
             if not http_annotation_original and http_annotation_update:
                 FindingContainer.addFinding(
                     category=FindingCategory.HTTP_ANNOTATION_ADDITION,
-                    location=f"{method_update.proto_file_name} Line: {method_update.http_annotation.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.http_annotation.source_code_line,
                     message="A google.api.http annotation is added.",
                     actionable=False,
                 )
@@ -187,7 +198,8 @@ class ServiceComparator:
             ) != http_annotation_update.get(annotation[0], annotation[1]):
                 FindingContainer.addFinding(
                     category=FindingCategory.HTTP_ANNOTATION_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.http_annotation.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.http_annotation.source_code_line,
                     message=annotation[2],
                     actionable=True,
                 )
@@ -201,7 +213,8 @@ class ServiceComparator:
         if not lro_original and lro_update:
             FindingContainer.addFinding(
                 category=FindingCategory.LRO_ANNOTATION_ADDITION,
-                location=f"{method_update.proto_file_name} Line: {method_update.lro_annotation.source_code_line}",
+                proto_file_name=method_update.proto_file_name,
+                source_code_line=method_update.lro_annotation.source_code_line,
                 message="A LRO operation_info annotation is added.",
                 actionable=False,
             )
@@ -210,7 +223,8 @@ class ServiceComparator:
         if lro_original and not lro_update:
             FindingContainer.addFinding(
                 category=FindingCategory.LRO_ANNOTATION_REMOVAL,
-                location=f"{method_original.proto_file_name} Line: {method_original.lro_annotation.source_code_line}",
+                proto_file_name=method_original.proto_file_name,
+                source_code_line=method_original.lro_annotation.source_code_line,
                 message="A LRO operation_info annotation is removed.",
                 actionable=False,
             )
@@ -219,7 +233,8 @@ class ServiceComparator:
         if lro_original.value["response_type"] != lro_update.value["response_type"]:
             FindingContainer.addFinding(
                 category=FindingCategory.LRO_RESPONSE_CHANGE,
-                location=f"{method_update.proto_file_name} Line: {lro_update.source_code_line}",
+                proto_file_name=method_update.proto_file_name,
+                source_code_line=lro_update.source_code_line,
                 message=f"The response_type of LRO operation_info annotation is changed from {lro_original.value['response_type']} to {lro_update.value['response_type']}",
                 actionable=True,
             )
@@ -227,7 +242,8 @@ class ServiceComparator:
         if lro_original.value["metadata_type"] != lro_update.value["metadata_type"]:
             FindingContainer.addFinding(
                 category=FindingCategory.LRO_METADATA_CHANGE,
-                location=f"{method_update.proto_file_name} Line: {lro_update.source_code_line}",
+                proto_file_name=method_update.proto_file_name,
+                source_code_line=lro_update.source_code_line,
                 message=f"The metadata_type of LRO operation_info annotation is changed from {lro_original.value['metadata_type']} to {lro_update.value['metadata_type']}",
                 actionable=True,
             )
@@ -238,7 +254,8 @@ class ServiceComparator:
         if len(signatures_original) > len(signatures_update):
             FindingContainer.addFinding(
                 category=FindingCategory.METHOD_SIGNATURE_CHANGE,
-                location=f"{method_original.proto_file_name} Line: {method_original.method_signatures.source_code_line}",
+                proto_file_name=method_original.proto_file_name,
+                source_code_line=method_original.method_signatures.source_code_line,
                 message="An existing method_signature is removed.",
                 actionable=True,
             )
@@ -246,7 +263,8 @@ class ServiceComparator:
             if old_sig != new_sig:
                 FindingContainer.addFinding(
                     category=FindingCategory.METHOD_SIGNATURE_CHANGE,
-                    location=f"{method_update.proto_file_name} Line: {method_update.method_signatures.source_code_line}",
+                    proto_file_name=method_update.proto_file_name,
+                    source_code_line=method_update.method_signatures.source_code_line,
                     message=f"An existing method_signature is changed from '{old_sig}' to '{new_sig}'.",
                     actionable=True,
                 )

--- a/src/findings/finding_container.py
+++ b/src/findings/finding_container.py
@@ -24,13 +24,21 @@ class FindingContainer:
     def addFinding(
         cls,
         category: FindingCategory,
-        location: str,
+        proto_file_name: str,
+        source_code_line: int,
         message: str,
         actionable: bool,
         extra_info=None,
     ):
         cls._finding_results.append(
-            Finding(category, location, message, actionable, extra_info)
+            Finding(
+                category,
+                proto_file_name,
+                source_code_line,
+                message,
+                actionable,
+                extra_info,
+            )
         )
 
     @classmethod

--- a/src/findings/utils.py
+++ b/src/findings/utils.py
@@ -60,24 +60,34 @@ class FindingCategory(enum.Enum):
 
 class Finding:
     class _Location:
-        path: str
+        proto_file_name: str
+        source_code_line: int
 
-        def __init__(self, path):
-            self.path = path
+        def __init__(self, proto_file_name, source_code_line):
+            self.proto_file_name = proto_file_name
+            self.source_code_line = source_code_line
 
-    def __init__(self, category, path, message, actionable, extra_info=None):
+    def __init__(
+        self,
+        category,
+        proto_file_name,
+        source_code_line,
+        message,
+        actionable,
+        extra_info=None,
+    ):
         self.category = category
-        self.location = self._Location(path)
+        self.location = self._Location(proto_file_name, source_code_line)
         self.message = message
         self.actionable = actionable
         self.extra_info = extra_info
-        self._path = path
 
     def toDict(self):
         return {
             "category": self.category.value,
             "location": {
-                "path": self._path,
+                "proto_file_name": self.location.proto_file_name,
+                "source_code_line": self.location.source_code_line,
             },
             "message": self.message,
             "actionable": self.actionable,

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -53,21 +53,24 @@ class EnumComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "An Enum PhoneType is removed")
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 10")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 10)
 
     def test_enum_addition(self):
         EnumComparator(None, self.enum_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Enum PhoneType is added.")
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
-        self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 10")
+        self.assertEqual(finding.location.proto_file_name, "message_v1beta1.proto")
+        self.assertEqual(finding.location.source_code_line, 10)
 
     def test_enum_value_change(self):
         EnumComparator(self.enum_original, self.enum_update).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new EnumValue SCHOOL is added.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
-        self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 14")
+        self.assertEqual(finding.location.proto_file_name, "message_v1beta1.proto")
+        self.assertEqual(finding.location.source_code_line, 14)
 
     def test_no_api_change(self):
         EnumComparator(self.enum_update, self.enum_update).compare()

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -50,14 +50,16 @@ class EnumValueComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "An EnumValue MOBILE is removed")
         self.assertEqual(finding.category.name, "ENUM_VALUE_REMOVAL")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 11")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 11)
 
     def test_enum_value_addition(self):
         EnumValueComparator(None, self.enumValue_home).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new EnumValue HOME is added.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 12")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 12)
 
     def test_name_change(self):
         EnumValueComparator(self.enumValue_mobile, self.enumValue_home).compare()
@@ -68,7 +70,8 @@ class EnumValueComparatorTest(unittest.TestCase):
             "is MOBILE, but the updated is HOME",
         )
         self.assertEqual(finding.category.name, "ENUM_VALUE_NAME_CHANGE")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 12")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 12)
 
     def test_no_api_change(self):
         EnumValueComparator(self.enumValue_mobile, self.enumValue_mobile).compare()

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -49,14 +49,16 @@ class FieldComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A Field name is removed")
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 6")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 6)
 
     def test_field_addition(self):
         FieldComparator(None, self.person_fields_v1[1]).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Field name is added.")
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 6")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 6)
 
     def test_type_change(self):
         # Field `id` is `int32` type in `message_v1.proto`,
@@ -98,7 +100,8 @@ class FieldComparatorTest(unittest.TestCase):
             "Name of the Field is changed, the original is email, but the updated is email_address",
         )
         self.assertEqual(finding.category.name, "FIELD_NAME_CHANGE")
-        self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 8")
+        self.assertEqual(finding.location.proto_file_name, "message_v1beta1.proto")
+        self.assertEqual(finding.location.source_code_line, 8)
 
     def test_oneof_change(self):
         # Field `single = 5` in `message_v1.proto` is moved out of One-of.
@@ -111,7 +114,8 @@ class FieldComparatorTest(unittest.TestCase):
             "The existing field single is moved out of One-of.",
         )
         self.assertEqual(finding.category.name, "FIELD_ONEOF_REMOVAL")
-        self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 22")
+        self.assertEqual(finding.location.proto_file_name, "message_v1beta1.proto")
+        self.assertEqual(finding.location.source_code_line, 22)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -43,7 +43,8 @@ class FileSetComparatorTest(unittest.TestCase):
             "The paginated response of method paginatedMethod is changed"
         ]
         self.assertEqual(finding.category.name, "METHOD_PAGINATED_RESPONSE_CHANGE")
-        self.assertEqual(finding.location.path, "service_v1beta1.proto Line: 11")
+        self.assertEqual(finding.location.proto_file_name, "service_v1beta1.proto")
+        self.assertEqual(finding.location.source_code_line, 11)
 
         _INVOKER_ORIGNAL.cleanup()
         _INVOKER_UPDATE.cleanup()
@@ -81,7 +82,8 @@ class FileSetComparatorTest(unittest.TestCase):
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         finding = findings_map["An Enum BookType is removed"]
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
-        self.assertEqual(finding.location.path, "enum_v1.proto Line: 5")
+        self.assertEqual(finding.location.proto_file_name, "enum_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 5)
         _INVOKER_ORIGNAL.cleanup()
         _INVOKER_UPDATE.cleanup()
 

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -53,14 +53,16 @@ class DescriptorComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A message Person is removed")
         self.assertEqual(finding.category.name, "MESSAGE_REMOVAL")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 5")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 5)
 
     def test_message_addition(self):
         DescriptorComparator(None, self.addressBook_msg).compare()
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new message AddressBook is added.")
         self.assertEqual(finding.category.name, "MESSAGE_ADDITION")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 27")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 27)
 
     def test_field_change(self):
         # There is field change in message `Person`. Type of field `id`
@@ -78,7 +80,8 @@ class DescriptorComparatorTest(unittest.TestCase):
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         finding = findings_map["A Field type is removed"]
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
-        self.assertEqual(finding.location.path, "message_v1.proto Line: 18")
+        self.assertEqual(finding.location.proto_file_name, "message_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 18)
 
     def test_nested_enum_change(self):
         # EnumValue `SCHOOL` in the nested enum `PhoneType` is added.
@@ -86,7 +89,8 @@ class DescriptorComparatorTest(unittest.TestCase):
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
         finding = findings_map["A new EnumValue SCHOOL is added."]
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
-        self.assertEqual(finding.location.path, "message_v1beta1.proto Line: 14")
+        self.assertEqual(finding.location.proto_file_name, "message_v1beta1.proto")
+        self.assertEqual(finding.location.source_code_line, 14)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/comparator/test_service_comparator.py
+++ b/test/comparator/test_service_comparator.py
@@ -54,7 +54,8 @@ class DescriptorComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A service Example is removed")
         self.assertEqual(finding.category.name, "SERVICE_REMOVAL")
-        self.assertEqual(finding.location.path, "service_v1.proto Line: 5")
+        self.assertEqual(finding.location.proto_file_name, "service_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 5)
 
     def test_service_addition(self):
         ServiceComparator(
@@ -64,7 +65,8 @@ class DescriptorComparatorTest(unittest.TestCase):
         finding = FindingContainer.getAllFindings()[0]
         self.assertEqual(finding.message, "A new service Example is added.")
         self.assertEqual(finding.category.name, "SERVICE_ADDITION")
-        self.assertEqual(finding.location.path, "service_v1.proto Line: 5")
+        self.assertEqual(finding.location.proto_file_name, "service_v1.proto")
+        self.assertEqual(finding.location.source_code_line, 5)
 
     def test_method_change(self):
         ServiceComparator(
@@ -72,18 +74,23 @@ class DescriptorComparatorTest(unittest.TestCase):
             self.service_update,
         ).compare()
         findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        # Method removal.
         method_removal_finding = findings_map["An rpc method shouldRemove is removed"]
         self.assertEqual(method_removal_finding.category.name, "METHOD_REMOVAL")
         self.assertEqual(
-            method_removal_finding.location.path, "service_v1.proto Line: 11"
+            method_removal_finding.location.proto_file_name, "service_v1.proto"
         )
+        self.assertEqual(method_removal_finding.location.source_code_line, 11)
+        # Input type change.
         method_input_change = findings_map[
             "Input type of method Foo is changed from FooRequest to FooRequestUpdate"
         ]
         self.assertEqual(method_input_change.category.name, "METHOD_INPUT_TYPE_CHANGE")
         self.assertEqual(
-            method_input_change.location.path, "service_v1beta1.proto Line: 7"
+            method_input_change.location.proto_file_name, "service_v1beta1.proto"
         )
+        self.assertEqual(method_input_change.location.source_code_line, 7)
+        # Output type change.
         method_output_change = findings_map[
             "Output type of method Foo is changed from FooResponse to FooResponseUpdate"
         ]
@@ -91,8 +98,10 @@ class DescriptorComparatorTest(unittest.TestCase):
             method_output_change.category.name, "METHOD_RESPONSE_TYPE_CHANGE"
         )
         self.assertEqual(
-            method_output_change.location.path, "service_v1beta1.proto Line: 7"
+            method_output_change.location.proto_file_name, "service_v1beta1.proto"
         )
+        self.assertEqual(method_output_change.location.source_code_line, 7)
+        # Streaming state change.
         method_client_streaming_change = findings_map[
             "The request streaming type of method Bar is changed"
         ]
@@ -101,21 +110,33 @@ class DescriptorComparatorTest(unittest.TestCase):
             "METHOD_CLIENT_STREAMING_CHANGE",
         )
         self.assertEqual(
-            method_client_streaming_change.location.path,
-            "service_v1beta1.proto Line: 9",
+            method_client_streaming_change.location.proto_file_name,
+            "service_v1beta1.proto",
         )
+        self.assertEqual(method_client_streaming_change.location.source_code_line, 9)
+        method_server_streaming_change = findings_map[
+            "The response streaming type of method Bar is changed"
+        ]
         self.assertEqual(
-            findings_map[
-                "The response streaming type of method Bar is changed"
-            ].category.name,
+            method_server_streaming_change.category.name,
             "METHOD_SERVER_STREAMING_CHANGE",
         )
         self.assertEqual(
-            findings_map[
-                "The paginated response of method paginatedMethod is changed"
-            ].category.name,
-            "METHOD_PAGINATED_RESPONSE_CHANGE",
+            method_server_streaming_change.location.proto_file_name,
+            "service_v1beta1.proto",
         )
+        self.assertEqual(method_server_streaming_change.location.source_code_line, 9)
+        # Paginated state change.
+        paginated_change = findings_map[
+            "The paginated response of method paginatedMethod is changed"
+        ]
+        self.assertEqual(
+            paginated_change.category.name, "METHOD_PAGINATED_RESPONSE_CHANGE"
+        )
+        self.assertEqual(
+            paginated_change.location.proto_file_name, "service_v1beta1.proto"
+        )
+        self.assertEqual(paginated_change.location.source_code_line, 11)
 
     def test_method_signature_change(self):
         ServiceComparator(
@@ -128,8 +149,9 @@ class DescriptorComparatorTest(unittest.TestCase):
         ]
         self.assertEqual(finding.category.name, "METHOD_SIGNATURE_CHANGE")
         self.assertEqual(
-            finding.location.path, "service_annotation_v1beta1.proto Line: 18"
+            finding.location.proto_file_name, "service_annotation_v1beta1.proto"
         )
+        self.assertEqual(finding.location.source_code_line, 18)
 
     def test_lro_annotation_change(self):
         ServiceComparator(
@@ -142,8 +164,9 @@ class DescriptorComparatorTest(unittest.TestCase):
         ]
         self.assertEqual(finding.category.name, "LRO_METADATA_CHANGE")
         self.assertEqual(
-            finding.location.path, "service_annotation_v1beta1.proto Line: 26"
+            finding.location.proto_file_name, "service_annotation_v1beta1.proto"
         )
+        self.assertEqual(finding.location.source_code_line, 26)
 
     def test_http_annotation_change(self):
         ServiceComparator(
@@ -160,19 +183,22 @@ class DescriptorComparatorTest(unittest.TestCase):
 
         self.assertEqual(uri_change_finding.category.name, "HTTP_ANNOTATION_CHANGE")
         self.assertEqual(
-            uri_change_finding.location.path,
-            "service_annotation_v1beta1.proto Line: 14",
+            uri_change_finding.location.proto_file_name,
+            "service_annotation_v1beta1.proto",
         )
+        self.assertEqual(uri_change_finding.location.source_code_line, 14)
         self.assertEqual(method_change_finding.category.name, "HTTP_ANNOTATION_CHANGE")
         self.assertEqual(
-            method_change_finding.location.path,
-            "service_annotation_v1beta1.proto Line: 14",
+            method_change_finding.location.proto_file_name,
+            "service_annotation_v1beta1.proto",
         )
+        self.assertEqual(method_change_finding.location.source_code_line, 14)
         self.assertEqual(body_change_finding.category.name, "HTTP_ANNOTATION_CHANGE")
         self.assertEqual(
-            body_change_finding.location.path,
-            "service_annotation_v1beta1.proto Line: 22",
+            body_change_finding.location.proto_file_name,
+            "service_annotation_v1beta1.proto",
         )
+        self.assertEqual(body_change_finding.location.source_code_line, 22)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Split the `finding.location.path (str)` to a structure `finding.location {proto_file_name: str, source_code_line: int}`. It's helpful that we use machine-readable object than a string value. We will convert to human-readable message if it's needed to output.

Currently we give `{proto_file_name: "", source_code_line:0}` for those non-supported source code location, but that will be updated in the upcoming PRs.