### PR TITLE
feat: use mock enum_value in unit test

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -84,6 +84,8 @@ class EnumValue:
     @property
     def source_code_line(self):
         """Return the start line number of source code in the proto file."""
+        if self.path not in self.source_code_locations:
+            return f"No source code line can be identified by path {self.path}."
         location = self.source_code_locations[self.path]
         # The line number in `span` is zero-based, +1 to get the actual line number in .proto file.
         return location.span[0] + 1

--- a/test/comparator/wrappers/test_enum_value.py
+++ b/test/comparator/wrappers/test_enum_value.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from test.tools.mock_descriptors import make_enum_value
+from google.protobuf import descriptor_pb2
+
+
+class EnumValueTest(unittest.TestCase):
+    def test_basic_properties(self):
+        enum_value = make_enum_value("FOO", 1)
+        self.assertEqual(enum_value.name, "FOO")
+        self.assertEqual(enum_value.number, 1)
+        self.assertEqual(enum_value.proto_file_name, "foo")
+        self.assertEqual(
+            enum_value.source_code_line,
+            "No source code line can be identified by path ().",
+        )
+        self.assertEqual(enum_value.path, ())
+
+    def test_extra_properties(self):
+        L = descriptor_pb2.SourceCodeInfo.Location
+        location = L(path=(4, 0, 2, 0), span=(1, 2, 3, 4))
+        enum_value = make_enum_value(
+            name="FOO",
+            number=1,
+            proto_file_name="foo.proto",
+            source_code_locations={(4, 0, 2, 0): location},
+            path=(4, 0, 2, 0),
+        )
+        self.assertEqual(enum_value.name, "FOO")
+        self.assertEqual(enum_value.number, 1)
+        self.assertEqual(enum_value.proto_file_name, "foo.proto")
+        self.assertEqual(
+            enum_value.source_code_line,
+            2,
+        )
+        self.assertEqual(enum_value.path, (4, 0, 2, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tools/mock_descriptors.py
+++ b/test/tools/mock_descriptors.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Tuple
+from google.protobuf import descriptor_pb2 as desc
+import src.comparator.wrappers as wrappers
+
+
+def make_enum_value_pb2(
+    name: str, number: int, **kwargs
+) -> desc.EnumValueDescriptorProto:
+    return desc.EnumValueDescriptorProto(name=name, number=number)
+
+
+def make_enum_value(
+    name: str,
+    number: int,
+    proto_file_name: str = "foo",
+    source_code_locations: Dict[Tuple[int, ...], desc.SourceCodeInfo.Location] = {},
+    path: Tuple[int] = (),
+) -> wrappers.EnumValue:
+    enum_value_pb = make_enum_value_pb2(name, number)
+    enum_value = wrappers.EnumValue(
+        enum_value_pb, proto_file_name, source_code_locations, path
+    )
+    return enum_value

--- a/test/tools/mock_descriptors.py
+++ b/test/tools/mock_descriptors.py
@@ -20,6 +20,7 @@ import src.comparator.wrappers as wrappers
 def make_enum_value_pb2(
     name: str, number: int, **kwargs
 ) -> desc.EnumValueDescriptorProto:
+    """Mock an EnumValueDescriptorProto that is used to create wrappers.EnumValue"""
     return desc.EnumValueDescriptorProto(name=name, number=number)
 
 
@@ -30,6 +31,7 @@ def make_enum_value(
     source_code_locations: Dict[Tuple[int, ...], desc.SourceCodeInfo.Location] = {},
     path: Tuple[int] = (),
 ) -> wrappers.EnumValue:
+    """Mock an EnumValue object."""
     enum_value_pb = make_enum_value_pb2(name, number)
     enum_value = wrappers.EnumValue(
         enum_value_pb, proto_file_name, source_code_locations, path


### PR DESCRIPTION
Motivation: currently our unit tests all run from FileSet level (read in proto file using protoc command and create fileDescriptorSet from there), to get the descriptor object like `EnumValueDescriptorProto`. But that also brings mixed-in behaviors from comparators in different level. And overall, unit test should be for testing a specific component, and integration test is to verify that the whole pipeline works all together. So we will use mocked objects for the unit tests, those objects are created in `mock_descriptor.py`. I will gradually move all the unit tests to use mock objects, so all the hard-code testdata can be removed. 

1. `mock_descriptors.py` is used to create wrapper objects that are defined in the `wrappers.py`.
2. Use mock EnumValue in `test_enum_value_comparator`.
3. Use mock EnumValue in `wrappers.test_enum_value` to get a better test coverage.

The `toos/invoker`  and `testdata/example` should be useful when we start to do integration tests. 