### PR TITLE
refactor: pass in finding container to each comparator

### DIFF
--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -19,15 +19,21 @@ from src.comparator.wrappers import Enum
 
 
 class EnumComparator:
-    def __init__(self, enum_original: Enum, enum_update: Enum):
+    def __init__(
+        self,
+        enum_original: Enum,
+        enum_update: Enum,
+        finding_container: FindingContainer,
+    ):
         self.enum_original = enum_original
         self.enum_update = enum_update
+        self.finding_container = finding_container
 
     def compare(self):
         # 1. If original EnumDescriptor is None, then a new
         # EnumDescriptor is added.
         if self.enum_original is None:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.ENUM_ADDITION,
                 proto_file_name=self.enum_update.proto_file_name,
                 source_code_line=self.enum_update.source_code_line,
@@ -38,7 +44,7 @@ class EnumComparator:
         # 2. If updated EnumDescriptor is None, then the original
         # EnumDescriptor is removed.
         elif self.enum_update is None:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.ENUM_REMOVAL,
                 proto_file_name=self.enum_original.proto_file_name,
                 source_code_line=self.enum_original.source_code_line,
@@ -56,12 +62,22 @@ class EnumComparator:
             enum_values_keys_set_update = set(enum_values_dict_update.keys())
             # Compare Enum values that only exist in original version
             for number in enum_values_keys_set_original - enum_values_keys_set_update:
-                EnumValueComparator(enum_values_dict_original[number], None).compare()
+                EnumValueComparator(
+                    enum_values_dict_original[number],
+                    None,
+                    self.finding_container,
+                ).compare()
             # Compare Enum values that only exist in update version
             for number in enum_values_keys_set_update - enum_values_keys_set_original:
-                EnumValueComparator(None, enum_values_dict_update[number]).compare()
+                EnumValueComparator(
+                    None,
+                    enum_values_dict_update[number],
+                    self.finding_container,
+                ).compare()
             # Compare Enum values that exist both in original and update versions
             for number in enum_values_keys_set_original & enum_values_keys_set_update:
                 EnumValueComparator(
-                    enum_values_dict_original[number], enum_values_dict_update[number]
+                    enum_values_dict_original[number],
+                    enum_values_dict_update[number],
+                    self.finding_container,
                 ).compare()

--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -22,14 +22,16 @@ class EnumValueComparator:
         self,
         enum_value_original: EnumValue,
         enum_value_update: EnumValue,
+        finding_container: FindingContainer,
     ):
         self.enum_value_original = enum_value_original
         self.enum_value_update = enum_value_update
+        self.finding_container = finding_container
 
     def compare(self):
         # 1. If original EnumValue is None, then a new EnumValue is added.
         if self.enum_value_original is None:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.ENUM_VALUE_ADDITION,
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,
@@ -38,7 +40,7 @@ class EnumValueComparator:
             )
         # 2. If updated EnumValue is None, then the original EnumValue is removed.
         elif self.enum_value_update is None:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.ENUM_VALUE_REMOVAL,
                 proto_file_name=self.enum_value_original.proto_file_name,
                 source_code_line=self.enum_value_original.source_code_line,
@@ -47,7 +49,7 @@ class EnumValueComparator:
             )
         # 3. If both EnumValueDescriptors are existing, check if the name is changed.
         elif self.enum_value_original.name != self.enum_value_update.name:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.ENUM_VALUE_NAME_CHANGE,
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,

--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.protobuf.descriptor_pb2 import FileDescriptorSet
 from src.comparator.service_comparator import ServiceComparator
 from src.comparator.message_comparator import DescriptorComparator
 from src.comparator.enum_comparator import EnumComparator
@@ -26,9 +25,11 @@ class FileSetComparator:
         self,
         file_set_original: FileSet,
         file_set_update: FileSet,
+        finding_container: FindingContainer,
     ):
         self.fs_original = file_set_original
         self.fs_update = file_set_update
+        self.finding_container = finding_container
 
     def compare(self):
         # 1.Compare the per-language packaging options.
@@ -50,7 +51,7 @@ class FileSetComparator:
             language_option_update = set(packaging_options_update[option].keys())
             for language_option in language_option_original - language_option_update:
                 removed_option = packaging_options_original[option][language_option]
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                     proto_file_name=removed_option.proto_file_name,
                     source_code_line=removed_option.source_code_line,
@@ -59,7 +60,7 @@ class FileSetComparator:
                 )
             for language_option in language_option_update - language_option_original:
                 added_option = packaging_options_update[option][language_option]
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.PACKAGING_OPTION_ADDITION,
                     proto_file_name=added_option.proto_file_name,
                     source_code_line=added_option.source_code_line,
@@ -78,31 +79,51 @@ class FileSetComparator:
             ServiceComparator(
                 fs_original.services_map.get(name),
                 fs_update.services_map.get(name),
+                self.finding_container,
             ).compare()
 
     def _compare_messages(self, fs_original, fs_update):
         keys_original = set(fs_original.messages_map.keys())
         keys_update = set(fs_update.messages_map.keys())
         for name in keys_original - keys_update:
-            DescriptorComparator(fs_original.messages_map.get(name), None).compare()
+            DescriptorComparator(
+                fs_original.messages_map.get(name),
+                None,
+                self.finding_container,
+            ).compare()
         for name in keys_update - keys_original:
-            DescriptorComparator(None, fs_update.messages_map.get(name)).compare()
+            DescriptorComparator(
+                None,
+                fs_update.messages_map.get(name),
+                self.finding_container,
+            ).compare()
         for name in keys_update & keys_original:
             DescriptorComparator(
                 fs_original.messages_map.get(name),
                 fs_update.messages_map.get(name),
+                self.finding_container,
             ).compare()
 
     def _compare_enums(self, fs_original, fs_update):
         keys_original = set(fs_original.enums_map.keys())
         keys_update = set(fs_update.enums_map.keys())
         for name in keys_original - keys_update:
-            EnumComparator(fs_original.enums_map.get(name), None).compare()
+            EnumComparator(
+                fs_original.enums_map.get(name),
+                None,
+                self.finding_container,
+            ).compare()
         for name in keys_update - keys_original:
-            EnumComparator(None, fs_update.enums_map.get(name)).compare()
+            EnumComparator(
+                None,
+                fs_update.enums_map.get(name),
+                self.finding_container,
+            ).compare()
         for name in keys_update & keys_original:
             EnumComparator(
-                fs_original.enums_map.get(name), fs_update.enums_map.get(name)
+                fs_original.enums_map.get(name),
+                fs_update.enums_map.get(name),
+                self.finding_container,
             ).compare()
 
     def _compare_resources(self, fs_original, fs_update):
@@ -116,7 +137,7 @@ class FileSetComparator:
             patterns_update = resources_update.types[resource_type].value.pattern
             # An existing pattern is removed.
             if len(patterns_original) > len(patterns_update):
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
                     proto_file_name=resources_original.types[
                         resource_type
@@ -131,7 +152,7 @@ class FileSetComparator:
             # A new pattern value appended to the pattern list is not consider breaking change.
             for old_pattern, new_pattern in zip(patterns_original, patterns_update):
                 if old_pattern != new_pattern:
-                    FindingContainer.addFinding(
+                    self.finding_container.addFinding(
                         category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
                         proto_file_name=resources_update.types[
                             resource_type
@@ -145,7 +166,7 @@ class FileSetComparator:
 
         # 2. File-level resource definitions addition.
         for resource_type in resources_types_update - resources_types_original:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.RESOURCE_DEFINITION_ADDITION,
                 proto_file_name=resources_update.types[resource_type].proto_file_name,
                 source_code_line=resources_update.types[resource_type].source_code_line,

--- a/src/comparator/service_comparator.py
+++ b/src/comparator/service_comparator.py
@@ -22,14 +22,16 @@ class ServiceComparator:
         self,
         service_original: Service,
         service_update: Service,
+        finding_container: FindingContainer,
     ):
         self.service_original = service_original
         self.service_update = service_update
+        self.finding_container = finding_container
 
     def compare(self):
         # 1. If original service is None, then a new service is added.
         if self.service_original is None:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.SERVICE_ADDITION,
                 proto_file_name=self.service_update.proto_file_name,
                 source_code_line=self.service_update.source_code_line,
@@ -39,7 +41,7 @@ class ServiceComparator:
             return
         # 2. If updated service is None, then the original service is removed.
         if self.service_update is None:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.SERVICE_REMOVAL,
                 proto_file_name=self.service_original.proto_file_name,
                 source_code_line=self.service_original.source_code_line,
@@ -71,7 +73,7 @@ class ServiceComparator:
         # 3.1 An RPC method is removed.
         for name in methods_original_keys - methods_update_keys:
             removed_method = methods_original[name]
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.METHOD_REMOVAL,
                 proto_file_name=removed_method.proto_file_name,
                 source_code_line=removed_method.source_code_line,
@@ -81,7 +83,7 @@ class ServiceComparator:
         # 3.2 An RPC method is added.
         for name in methods_update_keys - methods_original_keys:
             added_method = methods_update[name]
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.METHOD_ADDTION,
                 proto_file_name=added_method.proto_file_name,
                 source_code_line=added_method.source_code_line,
@@ -95,7 +97,7 @@ class ServiceComparator:
             input_type_original = method_original.input.value
             input_type_update = method_update.input.value
             if input_type_original != input_type_update:
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.METHOD_INPUT_TYPE_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.input.source_code_line,
@@ -106,7 +108,7 @@ class ServiceComparator:
             response_type_original = method_original.output.value
             response_type_update = method_update.output.value
             if response_type_original != response_type_update:
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.METHOD_RESPONSE_TYPE_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.output.source_code_line,
@@ -118,7 +120,7 @@ class ServiceComparator:
                 method_original.client_streaming.value
                 != method_update.client_streaming.value
             ):
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.METHOD_CLIENT_STREAMING_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.client_streaming.source_code_line,
@@ -130,7 +132,7 @@ class ServiceComparator:
                 method_original.server_streaming.value
                 != method_update.server_streaming.value
             ):
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.METHOD_SERVER_STREAMING_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.server_streaming.source_code_line,
@@ -145,7 +147,7 @@ class ServiceComparator:
                     or method_original.paged_result_field.name
                     != method_update.paged_result_field.name
                 ):
-                    FindingContainer.addFinding(
+                    self.finding_container.addFinding(
                         category=FindingCategory.METHOD_PAGINATED_RESPONSE_CHANGE,
                         proto_file_name=method_update.proto_file_name,
                         source_code_line=method_update.source_code_line,
@@ -171,7 +173,7 @@ class ServiceComparator:
             # except for bi-directional streaming RPCs, so the http_annotation addition/removal indicates
             # streaming state changes of the RPC, which is a breaking change.
             if http_annotation_original and not http_annotation_update:
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.HTTP_ANNOTATION_REMOVAL,
                     proto_file_name=method_original.proto_file_name,
                     source_code_line=method_original.http_annotation.source_code_line,
@@ -179,7 +181,7 @@ class ServiceComparator:
                     actionable=True,
                 )
             if not http_annotation_original and http_annotation_update:
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.HTTP_ANNOTATION_ADDITION,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.http_annotation.source_code_line,
@@ -209,7 +211,7 @@ class ServiceComparator:
             if http_annotation_original.get(
                 annotation[0], annotation[1]
             ) != http_annotation_update.get(annotation[0], annotation[1]):
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.HTTP_ANNOTATION_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.http_annotation.source_code_line,
@@ -224,7 +226,7 @@ class ServiceComparator:
             return
         # LRO operation_info annotation addition.
         if not lro_original and lro_update:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.LRO_ANNOTATION_ADDITION,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=method_update.lro_annotation.source_code_line,
@@ -234,7 +236,7 @@ class ServiceComparator:
             return
         # LRO operation_info annotation removal.
         if lro_original and not lro_update:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.LRO_ANNOTATION_REMOVAL,
                 proto_file_name=method_original.proto_file_name,
                 source_code_line=method_original.lro_annotation.source_code_line,
@@ -244,7 +246,7 @@ class ServiceComparator:
             return
         # The response_type value of LRO operation_info is changed.
         if lro_original.value["response_type"] != lro_update.value["response_type"]:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.LRO_RESPONSE_CHANGE,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=lro_update.source_code_line,
@@ -253,7 +255,7 @@ class ServiceComparator:
             )
         # The metadata_type value of LRO operation_info is changed.
         if lro_original.value["metadata_type"] != lro_update.value["metadata_type"]:
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.LRO_METADATA_CHANGE,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=lro_update.source_code_line,
@@ -265,7 +267,7 @@ class ServiceComparator:
         signatures_original = method_original.method_signatures.value
         signatures_update = method_update.method_signatures.value
         if len(signatures_original) > len(signatures_update):
-            FindingContainer.addFinding(
+            self.finding_container.addFinding(
                 category=FindingCategory.METHOD_SIGNATURE_CHANGE,
                 proto_file_name=method_original.proto_file_name,
                 source_code_line=method_original.method_signatures.source_code_line,
@@ -274,7 +276,7 @@ class ServiceComparator:
             )
         for old_sig, new_sig in zip(signatures_original, signatures_update):
             if old_sig != new_sig:
-                FindingContainer.addFinding(
+                self.finding_container.addFinding(
                     category=FindingCategory.METHOD_SIGNATURE_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.method_signatures.source_code_line,

--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -33,17 +33,19 @@ class Detector:
         self.descriptor_set_original = descriptor_set_original
         self.descriptor_set_update = descriptor_set_update
         self.opts = opts
+        self.finding_container = FindingContainer()
 
     def detect_breaking_changes(self):
         # Init FileSetComparator and compare the two FileDescriptorSet.
         FileSetComparator(
             FileSet(self.descriptor_set_original, self.opts.package_prefixes),
             FileSet(self.descriptor_set_update, self.opts.package_prefixes),
+            self.finding_container,
         ).compare()
         # Output json file of findings and human-readable messages if the
         # command line option is enabled.
         with open(self.opts.output_json_path, "w") as write_json_file:
-            json.dump(FindingContainer.toDictArr(), write_json_file)
+            json.dump(self.finding_container.toDictArr(), write_json_file)
 
         if self.opts.human_readable_message:
-            sys.stdout.write(FindingContainer.toHumanReadableMessage())
+            sys.stdout.write(self.finding_container.toHumanReadableMessage())

--- a/src/findings/finding_container.py
+++ b/src/findings/finding_container.py
@@ -18,11 +18,11 @@ from collections import defaultdict
 
 
 class FindingContainer:
-    _finding_results = []
+    def __init__(self):
+        self.finding_results = []
 
-    @classmethod
     def addFinding(
-        cls,
+        self,
         category: FindingCategory,
         proto_file_name: str,
         source_code_line: int,
@@ -30,7 +30,7 @@ class FindingContainer:
         actionable: bool,
         extra_info=None,
     ):
-        cls._finding_results.append(
+        self.finding_results.append(
             Finding(
                 category,
                 proto_file_name,
@@ -41,23 +41,19 @@ class FindingContainer:
             )
         )
 
-    @classmethod
-    def getAllFindings(cls):
-        return cls._finding_results
+    def getAllFindings(self):
+        return self.finding_results
 
-    @classmethod
-    def getActionableFindings(cls):
-        return [finding for finding in cls._finding_results if finding.actionable]
+    def getActionableFindings(self):
+        return [finding for finding in self.finding_results if finding.actionable]
 
-    @classmethod
-    def toDictArr(cls):
-        return [finding.toDict() for finding in cls._finding_results]
+    def toDictArr(self):
+        return [finding.toDict() for finding in self.finding_results]
 
-    @classmethod
-    def toHumanReadableMessage(cls):
+    def toHumanReadableMessage(self):
         output_message = ""
         file_to_findings = defaultdict(list)
-        for finding in cls.getActionableFindings():
+        for finding in self.getActionableFindings():
             # Create a map to summarize the findings based on proto file name.s
             file_to_findings[finding.location.proto_file_name].append(finding)
         # Add each finding to the output message.
@@ -68,7 +64,3 @@ class FindingContainer:
             for finding in findings:
                 output_message += f"{file_name} L{finding.location.source_code_line}: {finding.message}\n"
         return output_message
-
-    @classmethod
-    def reset(cls):
-        cls._finding_results = []

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -13,13 +13,9 @@ from click.testing import CliRunner
 from src.cli.detect import detect
 from unittest.mock import patch
 from io import StringIO
-from src.findings.finding_container import FindingContainer
 
 
 class CliDetectTest(unittest.TestCase):
-    def tearDown(self):
-        FindingContainer.reset()
-
     def test_descriptor_set_enum(self):
         # Mock the stdout so that the unit test does not
         # print anything to the console.

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -47,38 +47,36 @@ class EnumComparatorTest(unittest.TestCase):
             locations=locations,
             path=(4, 0,),
         )
+        self.finding_container = FindingContainer()
         # fmt: on
 
-    def tearDown(self):
-        FindingContainer.reset()
-
     def test_enum_removal(self):
-        EnumComparator(self.enum_foo, None).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        EnumComparator(self.enum_foo, None, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "An Enum `Foo` is removed.")
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_enum_addition(self):
-        EnumComparator(None, self.enum_bar).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        EnumComparator(None, self.enum_bar, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "A new Enum `Bar` is added.")
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_enum_value_change(self):
-        EnumComparator(self.enum_foo, self.enum_bar).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        EnumComparator(self.enum_foo, self.enum_bar, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "A new EnumValue `VALUE2` is added.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
         self.assertEqual(finding.location.source_code_line, 3)
 
     def test_no_api_change(self):
-        EnumComparator(self.enum_foo, self.enum_foo).compare()
-        self.assertEqual(len(FindingContainer.getAllFindings()), 0)
+        EnumComparator(self.enum_foo, self.enum_foo, self.finding_container).compare()
+        self.assertEqual(len(self.finding_container.getAllFindings()), 0)
 
 
 if __name__ == "__main__":

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -37,29 +37,33 @@ class EnumValueComparatorTest(unittest.TestCase):
             locations=locations,
             path=(2, 1),
         )
-
-    def tearDown(self):
-        FindingContainer.reset()
+        self.finding_container = FindingContainer()
 
     def test_enum_value_removal(self):
-        EnumValueComparator(self.enum_foo, None).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        EnumValueComparator(
+            self.enum_foo,
+            None,
+            self.finding_container,
+        ).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "An EnumValue `FOO` is removed.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_enum_value_addition(self):
-        EnumValueComparator(None, self.enum_foo).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        EnumValueComparator(None, self.enum_foo, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "A new EnumValue `FOO` is added.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_name_change(self):
-        EnumValueComparator(self.enum_foo, self.enum_bar).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        EnumValueComparator(
+            self.enum_foo, self.enum_bar, self.finding_container
+        ).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(
             finding.message, "Name of the EnumValue is changed from `FOO` to `BAR`."
         )
@@ -68,8 +72,10 @@ class EnumValueComparatorTest(unittest.TestCase):
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_no_api_change(self):
-        EnumValueComparator(self.enum_foo, self.enum_foo).compare()
-        self.assertEqual(len(FindingContainer.getAllFindings()), 0)
+        EnumValueComparator(
+            self.enum_foo, self.enum_foo, self.finding_container
+        ).compare()
+        self.assertEqual(len(self.finding_container.getAllFindings()), 0)
 
 
 if __name__ == "__main__":

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -19,29 +19,29 @@ from src.findings.finding_container import FindingContainer
 
 
 class FieldComparatorTest(unittest.TestCase):
-    def tearDown(self):
-        FindingContainer.reset()
+    def setUp(self):
+        self.finding_container = FindingContainer()
 
     def test_field_removal(self):
         field_foo = make_field("Foo")
-        FieldComparator(field_foo, None).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        FieldComparator(field_foo, None, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "An existing field `Foo` is removed.")
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
     def test_field_addition(self):
         field_foo = make_field("Foo")
-        FieldComparator(None, field_foo).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        FieldComparator(None, field_foo, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.message, "A new field `Foo` is added.")
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
 
     def test_primitive_type_change(self):
         field_int = make_field(proto_type="TYPE_INT32")
         field_string = make_field(proto_type="TYPE_STRING")
-        FieldComparator(field_int, field_string).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        FieldComparator(field_int, field_string, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(
             finding.message,
             "Type of an existing field `my_field` is changed from `TYPE_INT32` to `TYPE_STRING`.",
@@ -51,8 +51,10 @@ class FieldComparatorTest(unittest.TestCase):
     def test_message_type_change(self):
         field_message = make_field(type_name=".example.v1.Enum")
         field_message_update = make_field(type_name=".example.v1beta1.EnumUpdate")
-        FieldComparator(field_message, field_message_update).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        FieldComparator(
+            field_message, field_message_update, self.finding_container
+        ).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(
             finding.message,
             "Type of an existing field `my_field` is changed from `.example.v1.Enum` to `.example.v1beta1.EnumUpdate`.",
@@ -62,8 +64,10 @@ class FieldComparatorTest(unittest.TestCase):
     def test_repeated_label_change(self):
         field_repeated = make_field(repeated=True)
         field_non_repeated = make_field(repeated=False)
-        FieldComparator(field_repeated, field_non_repeated).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        FieldComparator(
+            field_repeated, field_non_repeated, self.finding_container
+        ).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(
             finding.message,
             "Repeated state of an existing field `my_field` is changed from `LABEL_REPEATED` to `LABEL_OPTIONAL`.",
@@ -73,8 +77,8 @@ class FieldComparatorTest(unittest.TestCase):
     def test_name_change(self):
         field_foo = make_field("Foo")
         field_bar = make_field("Bar")
-        FieldComparator(field_foo, field_bar).compare()
-        finding = FindingContainer.getAllFindings()[0]
+        FieldComparator(field_foo, field_bar, self.finding_container).compare()
+        finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(
             finding.message,
             "Name of an existing field is changed from `Foo` to `Bar`.",
@@ -84,8 +88,8 @@ class FieldComparatorTest(unittest.TestCase):
     def test_oneof_change(self):
         field_oneof = make_field(name="Foo", oneof=True)
         field_not_oneof = make_field(name="Foo")
-        FieldComparator(field_oneof, field_not_oneof).compare()
-        findings = {f.message: f for f in FindingContainer.getAllFindings()}
+        FieldComparator(field_oneof, field_not_oneof, self.finding_container).compare()
+        findings = {f.message: f for f in self.finding_container.getAllFindings()}
         finding = findings["An existing field `Foo` is moved out of One-of."]
         self.assertEqual(finding.category.name, "FIELD_ONEOF_REMOVAL")
 

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -29,8 +29,8 @@ from google.api import resource_pb2
 
 
 class FileSetComparatorTest(unittest.TestCase):
-    def tearDown(self):
-        FindingContainer.reset()
+    def setUp(self):
+        self.finding_container = FindingContainer()
 
     def test_service_change(self):
         service_original = make_service(methods=(make_method(name="DoThing"),))
@@ -38,8 +38,9 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             make_file_set(files=[make_file_pb2(services=[service_original])]),
             make_file_set(files=[make_file_pb2(services=[service_update])]),
+            self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         finding = findings_map["An existing rpc method `DoThing` is removed."]
         self.assertEqual(finding.category.name, "METHOD_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "my_proto.proto")
@@ -52,8 +53,9 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             make_file_set(files=[make_file_pb2(messages=[message_original])]),
             make_file_set(files=[make_file_pb2(messages=[message_update])]),
+            self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         finding = findings_map[
             "Name of an existing field is changed from `field_one` to `field_two`."
         ]
@@ -79,8 +81,9 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             make_file_set(files=[make_file_pb2(enums=[enum_original])]),
             make_file_set(files=[make_file_pb2(enums=[enum_update])]),
+            self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         finding = findings_map["An EnumValue `BLUE` is removed."]
         self.assertEqual(finding.category.name, "ENUM_VALUE_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "my_proto.proto")
@@ -111,8 +114,10 @@ class FileSetComparatorTest(unittest.TestCase):
         )
         file_set_update = make_file_set(files=[file_pb2])
 
-        FileSetComparator(file_set_original, file_set_update).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        FileSetComparator(
+            file_set_original, file_set_update, self.finding_container
+        ).compare()
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         file_resource_pattern_change = findings_map[
             "An existing pattern value of the resource definition `.example.v1.Bar` is updated from `foo/{foo}/bar/{bar}` to `foo/{foo}/bar/`."
         ]
@@ -140,8 +145,10 @@ class FileSetComparatorTest(unittest.TestCase):
             name="foo.proto", package=".example.v1", options=options_update
         )
         file_set_update = make_file_set(files=[file_pb2])
-        FileSetComparator(file_set_original, file_set_update).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        FileSetComparator(
+            file_set_original, file_set_update, self.finding_container
+        ).compare()
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         file_resource_addition = findings_map[
             "A file-level resource definition `.example.v1.Bar` has been added."
         ]
@@ -168,8 +175,9 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             make_file_set(files=[file_original]),
             make_file_set(files=[file_update]),
+            self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         go_package_option_removal = findings_map[
             "An exisiting packaging option for `php_namespace` is removed."
         ]

--- a/test/comparator/test_resources.py
+++ b/test/comparator/test_resources.py
@@ -30,8 +30,8 @@ class ResourceReferenceTest(unittest.TestCase):
     # create a FileDescriptorSet (_PB_ORIGNAL and _PB_UPDATE) out of it.
     PROTO_DIR = os.path.join(os.getcwd(), "test/testdata/protos/example/")
 
-    def tearDown(self):
-        FindingContainer.reset()
+    def setUp(self):
+        self.finding_container = FindingContainer()
 
     def test_resources_change(self):
         _INVOKER_ORIGNAL = Loader(
@@ -45,8 +45,9 @@ class ResourceReferenceTest(unittest.TestCase):
         FileSetComparator(
             FileSet(_INVOKER_ORIGNAL.get_descriptor_set()),
             FileSet(_INVOKER_UPDATE.get_descriptor_set()),
+            self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         # An existing pattern of a file-level resource definition is changed.
         file_resource_pattern_change = findings_map[
             "An existing pattern value of the resource definition `example.googleapis.com/t2` is updated from `foo/{foo}/bar/{bar}/t2` to `foo/{foo}/bar/{bar}/t2_update`."
@@ -116,8 +117,9 @@ class ResourceReferenceTest(unittest.TestCase):
         FileSetComparator(
             FileSet(_INVOKER_ORIGNAL.get_descriptor_set()),
             FileSet(_INVOKER_UPDATE.get_descriptor_set()),
+            self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in FindingContainer.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         # Type of the resource_reference is changed from type to child_type, but
         # they can not be resoved to the identical resource. Breaking change.
         finding = findings_map[
@@ -133,7 +135,7 @@ class ResourceReferenceTest(unittest.TestCase):
         # but it is added in message-level. Non-breaking change.
         # 2. File-level resource definition `t2` is removed, but is added
         # to message-level resource. Non-breaking change.
-        breaking_changes = FindingContainer.getActionableFindings()
+        breaking_changes = self.finding_container.getActionableFindings()
         self.assertEqual(len(breaking_changes), 1)
 
 

--- a/test/findings/test_finding_container.py
+++ b/test/findings/test_finding_container.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import json
 from src.findings.finding_container import FindingContainer
 from src.findings.utils import FindingCategory
 
@@ -23,40 +22,42 @@ class FindingContainerTest(unittest.TestCase):
     # automatically, so test_reset() will be run in the middle which will break us.
     # This is a monolithic test, so we give numbers to indicate
     # the steps and also ensure the execution orders.
+    finding_container = FindingContainer()
+
     def test1_add_findings(self):
-        FindingContainer.addFinding(
+        self.finding_container.addFinding(
             category=FindingCategory.METHOD_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=12,
             message="An rpc method bar is removed.",
             actionable=True,
         )
-        self.assertEqual(len(FindingContainer.getAllFindings()), 1)
+        self.assertEqual(len(self.finding_container.getAllFindings()), 1)
 
     def test2_get_actionable_findings(self):
-        FindingContainer.addFinding(
+        self.finding_container.addFinding(
             category=FindingCategory.FIELD_ADDITION,
             proto_file_name="my_proto.proto",
             source_code_line=15,
             message="Not breaking change.",
             actionable=False,
         )
-        self.assertEqual(len(FindingContainer.getActionableFindings()), 1)
+        self.assertEqual(len(self.finding_container.getActionableFindings()), 1)
 
     def test3_toDictArr(self):
-        dict_arr_output = FindingContainer.toDictArr()
+        dict_arr_output = self.finding_container.toDictArr()
         self.assertEqual(dict_arr_output[0]["category"], "METHOD_REMOVAL")
         self.assertEqual(dict_arr_output[1]["category"], "FIELD_ADDITION")
 
     def test4_toHumanReadableMessage(self):
-        FindingContainer.addFinding(
+        self.finding_container.addFinding(
             category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
             proto_file_name="my_proto.proto",
             source_code_line=5,
             message="An existing file-level resource definition has changed.",
             actionable=True,
         )
-        FindingContainer.addFinding(
+        self.finding_container.addFinding(
             category=FindingCategory.METHOD_SIGNATURE_CHANGE,
             proto_file_name="my_other_proto.proto",
             source_code_line=16,
@@ -64,15 +65,11 @@ class FindingContainerTest(unittest.TestCase):
             actionable=True,
         )
         self.assertEqual(
-            FindingContainer.toHumanReadableMessage(),
+            self.finding_container.toHumanReadableMessage(),
             "my_proto.proto L5: An existing file-level resource definition has changed.\n"
             + "my_proto.proto L12: An rpc method bar is removed.\n"
             + "my_other_proto.proto L16: An existing method_signature is changed from 'sig1' to 'sig2'.\n",
         )
-
-    def test5_reset(self):
-        FindingContainer.reset()
-        self.assertEqual(len(FindingContainer.getAllFindings()), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The original design for making the `finding_results` as a global variable is to avoid passing the finding_container to each comparator. But that also brings the need to **reset** the finding container for each unit test. 

Refactor the finding results as a property of `FindingContainer` instance.  We can create the finding container instance for the file set comparator and pass down for the nested descriptors.