### PR TITLE
feat: add separate cli option for descriptor set

### DIFF
--- a/src/detector/options.py
+++ b/src/detector/options.py
@@ -52,20 +52,23 @@ class Options:
         )
         self.original_descriptor_set_file_path = original_descriptor_set_file_path
         self.update_descriptor_set_file_path = update_descriptor_set_file_path
+        # Check the arguments are valid for detection.
         if not self._valid_arguments():
             raise _InvalidArgumentsException(
-                "Either dectories of the proto definintion files or path of the descriptor set file should be specified."
+                "Either directories of the proto definition files or path of the descriptor set files should be specified."
             )
         self.package_prefixes = self._get_package_prefixes(package_prefixes)
         self.human_readable_message = human_readable_message
         self.output_json_path = self._get_output_json_path(output_json_path)
 
     def use_proto_dirs(self) -> bool:
+        # User pass in the directorirs of proto definition files as input.
         if not self.original_api_definition_dirs or not self.update_api_definition_dirs:
             return False
         return True
 
     def use_descriptor_set(self) -> bool:
+        # User pass in the path of descriptor set files as input.
         if (
             not self.original_descriptor_set_file_path
             or not self.update_descriptor_set_file_path
@@ -74,6 +77,10 @@ class Options:
         return True
 
     def _valid_arguments(self) -> bool:
+        # Either directories of the proto definition files or path of 
+        # the descriptor set files should be specified. And the pass in
+        # directory or file path should be valid. Else return False.
+
         if not self.use_proto_dirs() and not self.use_descriptor_set():
             return False
         if self.use_proto_dirs():
@@ -96,6 +103,8 @@ class Options:
         return [prefix.strip() for prefix in prefixes.split(",")]
 
     def _get_output_json_path(self, path):
+        # Return the path of json output file, use default path if not set.
+        # Raise error if the specified path is not valid.
         if not path:
             return os.path.join(os.getcwd(), "detected_breaking_changes.json")
         elif not os.path.isfile(path):
@@ -103,12 +112,14 @@ class Options:
         return path
 
     def _check_valid_dirs(self, dirs) -> bool:
+        # Return True if the directories path are valid, else False.
         for directory in dirs:
             if not os.path.isdir(directory):
                 raise TypeError(f"The directory {directory} is not existing.")
         return True
 
     def _check_valid_file(self, file) -> bool:
+        # Return True if the file path is valid, else False.
         if not os.path.isfile(file):
             raise TypeError(f"The file {file} is not existing.")
         return True

--- a/src/detector/options.py
+++ b/src/detector/options.py
@@ -77,7 +77,7 @@ class Options:
         return True
 
     def _valid_arguments(self) -> bool:
-        # Either directories of the proto definition files or path of 
+        # Either directories of the proto definition files or path of
         # the descriptor set files should be specified. And the pass in
         # directory or file path should be valid. Else return False.
 

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -24,8 +24,8 @@ class CliDetectTest(unittest.TestCase):
             result = runner.invoke(
                 detect,
                 [
-                    "test/testdata/protos/enum/v1/enum_descriptor_set.pb",
-                    "test/testdata/protos/enum/v1beta1/enum_descriptor_set.pb",
+                    "--original_descriptor_set_file_path=test/testdata/protos/enum/v1/enum_descriptor_set.pb",
+                    "--update_descriptor_set_file_path=test/testdata/protos/enum/v1beta1/enum_descriptor_set.pb",
                     "--human_readable_message",
                 ],
             )
@@ -42,8 +42,8 @@ class CliDetectTest(unittest.TestCase):
             result = runner.invoke(
                 detect,
                 [
-                    "test/testdata/protos/enum/v1",
-                    "test/testdata/protos/enum/v1beta1",
+                    "--original_api_definition_dirs=test/testdata/protos/enum/v1",
+                    "--update_api_definition_dirs=test/testdata/protos/enum/v1beta1",
                     "--human_readable_message",
                 ],
             )
@@ -58,8 +58,8 @@ class CliDetectTest(unittest.TestCase):
             result = runner.invoke(
                 detect,
                 [
-                    "test/testdata/protos/message/v1",
-                    "test/testdata/protos/message/v1beta1",
+                    "--original_api_definition_dirs=test/testdata/protos/message/v1",
+                    "--update_api_definition_dirs=test/testdata/protos/message/v1beta1",
                     "--human_readable_message",
                 ],
             )
@@ -79,8 +79,8 @@ class CliDetectTest(unittest.TestCase):
             result = runner.invoke(
                 detect,
                 [
-                    "test/testdata/protos/service/v1",
-                    "test/testdata/protos/service/v1beta1",
+                    "--original_api_definition_dirs=test/testdata/protos/service/v1",
+                    "--update_api_definition_dirs=test/testdata/protos/service/v1beta1",
                     "--human_readable_message",
                 ],
             )
@@ -105,8 +105,8 @@ class CliDetectTest(unittest.TestCase):
             result = runner.invoke(
                 detect,
                 [
-                    "test/testdata/protos/service_annotation/v1",
-                    "test/testdata/protos/service_annotation/v1beta1",
+                    "--original_api_definition_dirs=test/testdata/protos/service_annotation/v1",
+                    "--update_api_definition_dirs=test/testdata/protos/service_annotation/v1beta1",
                     "--human_readable_message",
                 ],
             )
@@ -130,8 +130,8 @@ class CliDetectTest(unittest.TestCase):
             result = runner.invoke(
                 detect,
                 [
-                    "test/testdata/protos/enum/v1,test/testdata/protos/message/v1",
-                    "test/testdata/protos/enum/v1beta1,test/testdata/protos/message/v1beta1",
+                    "--original_api_definition_dirs=test/testdata/protos/enum/v1,test/testdata/protos/message/v1",
+                    "--update_api_definition_dirs=test/testdata/protos/enum/v1beta1,test/testdata/protos/message/v1beta1",
                     "--human_readable_message",
                 ],
             )

--- a/test/comparator/test_resource_database.py
+++ b/test/comparator/test_resource_database.py
@@ -24,6 +24,7 @@ class ResourceDatabaseTest(unittest.TestCase):
     PROTO_DIR = os.path.join(os.getcwd(), "test/testdata/protos/example/")
     INVOKER = Loader(
         [PROTO_DIR],
+        None,
         [os.path.join(PROTO_DIR, "resource_database_v1.proto")],
     )
 

--- a/test/comparator/test_resources.py
+++ b/test/comparator/test_resources.py
@@ -36,10 +36,12 @@ class ResourceReferenceTest(unittest.TestCase):
     def test_resources_change(self):
         _INVOKER_ORIGNAL = Loader(
             [self.PROTO_DIR],
+            None,
             [os.path.join(self.PROTO_DIR, "resource_database_v1.proto")],
         )
         _INVOKER_UPDATE = Loader(
             [self.PROTO_DIR],
+            None,
             [os.path.join(self.PROTO_DIR, "resource_database_v1beta1.proto")],
         )
         FileSetComparator(
@@ -108,10 +110,12 @@ class ResourceReferenceTest(unittest.TestCase):
     def test_resource_reference_change(self):
         _INVOKER_ORIGNAL = Loader(
             [self.PROTO_DIR],
+            None,
             [os.path.join(self.PROTO_DIR, "resource_reference_v1.proto")],
         )
         _INVOKER_UPDATE = Loader(
             [self.PROTO_DIR],
+            None,
             [os.path.join(self.PROTO_DIR, "resource_reference_v1beta1.proto")],
         )
         FileSetComparator(

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -26,6 +26,7 @@ class WrappersTest(unittest.TestCase):
     _CURRENT_DIR = os.getcwd()
     _INVOKER = Loader(
         [os.path.join(_CURRENT_DIR, "test/testdata/protos/example/")],
+        None,
         [os.path.join(_CURRENT_DIR, "test/testdata/protos/example/wrappers.proto")],
     )
     _FILE_SET = FileSet(_INVOKER.get_descriptor_set())

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -36,8 +36,10 @@ class DectetorTest(unittest.TestCase):
         with mock.patch("os.path.isdir") as mocked_isdir:
             mocked_isdir.return_value = True
             opts = Options(
-                proto_definition_original="c,d",
-                proto_definition_update="a,b",
+                original_api_definition_dirs="c,d",
+                update_api_definition_dirs="a,b",
+                original_descriptor_set_file_path=None,
+                update_descriptor_set_file_path=None,
                 human_readable_message=True,
             )
         with mock.patch("sys.stdout", new=StringIO()) as fakeOutput:

--- a/test/detector/test_loader.py
+++ b/test/detector/test_loader.py
@@ -24,6 +24,7 @@ class LoaderTest(unittest.TestCase):
     def test_loader_proto_dirs(self):
         loader = Loader(
             [os.path.join(self._CURRENT_DIR, "test/testdata/protos/example/")],
+            None,
             [
                 os.path.join(
                     self._CURRENT_DIR, "test/testdata/protos/example/wrappers.proto"
@@ -32,7 +33,7 @@ class LoaderTest(unittest.TestCase):
         )
         self.assertTrue(loader)
         self.assertEqual(
-            loader.proto_defintion,
+            loader.proto_defintion_dirs,
             [os.path.join(self._CURRENT_DIR, "test/testdata/protos/example/")],
         )
         self.assertEqual(
@@ -50,13 +51,14 @@ class LoaderTest(unittest.TestCase):
 
     def test_loader_descriptor_set(self):
         loader = Loader(
+            None,
             os.path.join(
                 self._CURRENT_DIR, "test/testdata/protos/enum/v1/enum_descriptor_set.pb"
-            )
+            ),
         )
         self.assertTrue(loader)
         self.assertEqual(
-            loader.proto_defintion,
+            loader.descriptor_set,
             os.path.join(
                 self._CURRENT_DIR, "test/testdata/protos/enum/v1/enum_descriptor_set.pb"
             ),

--- a/test/detector/test_options.py
+++ b/test/detector/test_options.py
@@ -136,7 +136,7 @@ class OptionsTest(unittest.TestCase):
                 mocked_isdir.return_value = True
                 with mock.patch("os.path.isfile") as mocked_isfile:
                     mocked_isfile.return_value = True
-                    # Either dectories of the proto definintion files or
+                    # Either directories of the proto definition files or
                     # path of the descriptor set file should be specified.
                     Options(
                         original_api_definition_dirs="a,b",


### PR DESCRIPTION
Since the detector accepts two types of inputs, and we use the same `original_api_definition ` and `update_api_definition ` to specify either 1) proto_definition_dirs 2) descriptor_set. The way to differ the two types is to verify the path is a file or directory array. To make the interface more generic and clearer, it makes more sense to use different command line options to pass in those variables.

1. Add command line option `--original_descriptor_set_file_path ` and `update_descriptor_set_file_path ` to accept the two versions descriptor set file path. 
2. Add checks to decide whether users pass in needed information for either way. Raise `_InvalidArgumentsException` if neither proto directories or descriptor set are set properly.