### PR TITLE
feat: add oslogin protos for integration test

### DIFF
--- a/test/testdata/protos/google/cloud/oslogin/common/common.proto
+++ b/test/testdata/protos/google/cloud/oslogin/common/common.proto
@@ -1,0 +1,111 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.oslogin.common;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+option csharp_namespace = "Google.Cloud.OsLogin.Common";
+option go_package = "google.golang.org/genproto/googleapis/cloud/oslogin/common;common";
+option java_outer_classname = "OsLoginProto";
+option java_package = "com.google.cloud.oslogin.common";
+option php_namespace = "Google\\Cloud\\OsLogin\\Common";
+option ruby_package = "Google::Cloud::OsLogin::Common";
+
+// Define a "User" resource owned by OS Login.
+option (google.api.resource_definition) = {
+  type: "oslogin.googleapis.com/User"
+  pattern: "users/{user}"
+};
+
+// The operating system options for account entries.
+enum OperatingSystemType {
+  // The operating system type associated with the user account information is
+  // unspecified.
+  OPERATING_SYSTEM_TYPE_UNSPECIFIED = 0;
+
+  // Linux user account information.
+  LINUX = 1;
+
+  // Windows user account information.
+  WINDOWS = 2;
+}
+
+// The POSIX account information associated with a Google account.
+message PosixAccount {
+  option (google.api.resource) = {
+    type: "oslogin.googleapis.com/PosixAccount"
+    pattern: "users/{user}/projects/{project}"
+  };
+
+  // Only one POSIX account can be marked as primary.
+  bool primary = 1;
+
+  // The username of the POSIX account.
+  string username = 2;
+
+  // The user ID.
+  int64 uid = 3;
+
+  // The default group ID.
+  int64 gid = 4;
+
+  // The path to the home directory for this account.
+  string home_directory = 5;
+
+  // The path to the logic shell for this account.
+  string shell = 6;
+
+  // The GECOS (user information) entry for this account.
+  string gecos = 7;
+
+  // System identifier for which account the username or uid applies to.
+  // By default, the empty value is used.
+  string system_id = 8;
+
+  // Output only. A POSIX account identifier.
+  string account_id = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The operating system type where this account applies.
+  OperatingSystemType operating_system_type = 10;
+
+  // Output only. The canonical resource name.
+  string name = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// The SSH public key information associated with a Google account.
+message SshPublicKey {
+  option (google.api.resource) = {
+    type: "oslogin.googleapis.com/SshPublicKey"
+    pattern: "users/{user}/sshPublicKeys/{fingerprint}"
+  };
+
+  // Public key text in SSH format, defined by
+  // <a href="https://www.ietf.org/rfc/rfc4253.txt" target="_blank">RFC4253</a>
+  // section 6.6.
+  string key = 1;
+
+  // An expiration time in microseconds since epoch.
+  int64 expiration_time_usec = 2;
+
+  // Output only. The SHA-256 fingerprint of the SSH public key.
+  string fingerprint = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The canonical resource name.
+  string name = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/test/testdata/protos/google/cloud/oslogin/v1/oslogin.proto
+++ b/test/testdata/protos/google/cloud/oslogin/v1/oslogin.proto
@@ -1,0 +1,212 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.oslogin.v1;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/cloud/oslogin/common/common.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option csharp_namespace = "Google.Cloud.OsLogin.V1";
+option go_package = "google.golang.org/genproto/googleapis/cloud/oslogin/v1;oslogin";
+option java_multiple_files = true;
+option java_outer_classname = "OsLoginProto";
+option java_package = "com.google.cloud.oslogin.v1";
+option php_namespace = "Google\\Cloud\\OsLogin\\V1";
+option ruby_package = "Google::Cloud::OsLogin::V1";
+
+// Cloud OS Login API
+//
+// The Cloud OS Login API allows you to manage users and their associated SSH
+// public keys for logging into virtual machines on Google Cloud Platform.
+service OsLoginService {
+  option (google.api.default_host) = "oslogin.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform,"
+      "https://www.googleapis.com/auth/compute";
+
+  // Deletes a POSIX account.
+  rpc DeletePosixAccount(DeletePosixAccountRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=users/*/projects/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Deletes an SSH public key.
+  rpc DeleteSshPublicKey(DeleteSshPublicKeyRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=users/*/sshPublicKeys/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Retrieves the profile information used for logging in to a virtual machine
+  // on Google Compute Engine.
+  rpc GetLoginProfile(GetLoginProfileRequest) returns (LoginProfile) {
+    option (google.api.http) = {
+      get: "/v1/{name=users/*}/loginProfile"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Retrieves an SSH public key.
+  rpc GetSshPublicKey(GetSshPublicKeyRequest) returns (google.cloud.oslogin.common.SshPublicKey) {
+    option (google.api.http) = {
+      get: "/v1/{name=users/*/sshPublicKeys/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Adds an SSH public key and returns the profile information. Default POSIX
+  // account information is set when no username and UID exist as part of the
+  // login profile.
+  rpc ImportSshPublicKey(ImportSshPublicKeyRequest) returns (ImportSshPublicKeyResponse) {
+    option (google.api.http) = {
+      post: "/v1/{parent=users/*}:importSshPublicKey"
+      body: "ssh_public_key"
+    };
+    option (google.api.method_signature) = "parent,ssh_public_key";
+    option (google.api.method_signature) = "parent,ssh_public_key,project_id";
+  }
+
+  // Updates an SSH public key and returns the profile information. This method
+  // supports patch semantics.
+  rpc UpdateSshPublicKey(UpdateSshPublicKeyRequest) returns (google.cloud.oslogin.common.SshPublicKey) {
+    option (google.api.http) = {
+      patch: "/v1/{name=users/*/sshPublicKeys/*}"
+      body: "ssh_public_key"
+    };
+    option (google.api.method_signature) = "name,ssh_public_key";
+    option (google.api.method_signature) = "name,ssh_public_key,update_mask";
+  }
+}
+
+// The user profile information used for logging in to a virtual machine on
+// Google Compute Engine.
+message LoginProfile {
+  // Required. A unique user ID.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of POSIX accounts associated with the user.
+  repeated google.cloud.oslogin.common.PosixAccount posix_accounts = 2;
+
+  // A map from SSH public key fingerprint to the associated key object.
+  map<string, google.cloud.oslogin.common.SshPublicKey> ssh_public_keys = 3;
+}
+
+// A request message for deleting a POSIX account entry.
+message DeletePosixAccountRequest {
+  // Required. A reference to the POSIX account to update. POSIX accounts are identified
+  // by the project ID they are associated with. A reference to the POSIX
+  // account is in format `users/{user}/projects/{project}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/PosixAccount"
+    }
+  ];
+}
+
+// A request message for deleting an SSH public key.
+message DeleteSshPublicKeyRequest {
+  // Required. The fingerprint of the public key to update. Public keys are identified by
+  // their SHA-256 fingerprint. The fingerprint of the public key is in format
+  // `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+}
+
+// A request message for retrieving the login profile information for a user.
+message GetLoginProfileRequest {
+  // Required. The unique ID for the user in format `users/{user}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "oslogin.googleapis.com/PosixAccount"
+    }
+  ];
+
+  // The project ID of the Google Cloud Platform project.
+  string project_id = 2;
+
+  // A system ID for filtering the results of the request.
+  string system_id = 3;
+}
+
+// A request message for retrieving an SSH public key.
+message GetSshPublicKeyRequest {
+  // Required. The fingerprint of the public key to retrieve. Public keys are identified
+  // by their SHA-256 fingerprint. The fingerprint of the public key is in
+  // format `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+}
+
+// A request message for importing an SSH public key.
+message ImportSshPublicKeyRequest {
+  // Required. The unique ID for the user in format `users/{user}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+
+  // Optional. The SSH public key and expiration time.
+  google.cloud.oslogin.common.SshPublicKey ssh_public_key = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // The project ID of the Google Cloud Platform project.
+  string project_id = 3;
+}
+
+// A response message for importing an SSH public key.
+message ImportSshPublicKeyResponse {
+  // The login profile information for the user.
+  LoginProfile login_profile = 1;
+}
+
+// A request message for updating an SSH public key.
+message UpdateSshPublicKeyRequest {
+  // Required. The fingerprint of the public key to update. Public keys are identified by
+  // their SHA-256 fingerprint. The fingerprint of the public key is in format
+  // `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+
+  // Required. The SSH public key and expiration time.
+  google.cloud.oslogin.common.SshPublicKey ssh_public_key = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Mask to control which fields get updated. Updates all if not present.
+  google.protobuf.FieldMask update_mask = 3;
+}

--- a/test/testdata/protos/google/cloud/oslogin/v1alpha/oslogin.proto
+++ b/test/testdata/protos/google/cloud/oslogin/v1alpha/oslogin.proto
@@ -1,0 +1,166 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.oslogin.v1alpha;
+
+import "google/api/annotations.proto";
+import "google/cloud/oslogin/common/common.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option csharp_namespace = "Google.Cloud.OsLogin.V1Alpha";
+option go_package = "google.golang.org/genproto/googleapis/cloud/oslogin/v1alpha;oslogin";
+option java_multiple_files = true;
+option java_outer_classname = "OsLoginProto";
+option java_package = "com.google.cloud.oslogin.v1alpha";
+option php_namespace = "Google\\Cloud\\OsLogin\\V1alpha";
+
+// Cloud OS Login API
+//
+// The Cloud OS Login API allows you to manage users and their associated SSH
+// public keys for logging into virtual machines on Google Cloud Platform.
+service OsLoginService {
+  // Deletes a POSIX account.
+  rpc DeletePosixAccount(DeletePosixAccountRequest)
+      returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1alpha/{name=users/*/projects/*}"
+    };
+  }
+
+  // Deletes an SSH public key.
+  rpc DeleteSshPublicKey(DeleteSshPublicKeyRequest)
+      returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1alpha/{name=users/*/sshPublicKeys/*}"
+    };
+  }
+
+  // Retrieves the profile information used for logging in to a virtual machine
+  // on Google Compute Engine.
+  rpc GetLoginProfile(GetLoginProfileRequest) returns (LoginProfile) {
+    option (google.api.http) = {
+      get: "/v1alpha/{name=users/*}/loginProfile"
+    };
+  }
+
+  // Retrieves an SSH public key.
+  rpc GetSshPublicKey(GetSshPublicKeyRequest)
+      returns (google.cloud.oslogin.common.SshPublicKey) {
+    option (google.api.http) = {
+      get: "/v1alpha/{name=users/*/sshPublicKeys/*}"
+    };
+  }
+
+  // Adds an SSH public key and returns the profile information. Default POSIX
+  // account information is set when no username and UID exist as part of the
+  // login profile.
+  rpc ImportSshPublicKey(ImportSshPublicKeyRequest)
+      returns (ImportSshPublicKeyResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=users/*}:importSshPublicKey"
+      body: "ssh_public_key"
+    };
+  }
+
+  // Updates an SSH public key and returns the profile information. This method
+  // supports patch semantics.
+  rpc UpdateSshPublicKey(UpdateSshPublicKeyRequest)
+      returns (google.cloud.oslogin.common.SshPublicKey) {
+    option (google.api.http) = {
+      patch: "/v1alpha/{name=users/*/sshPublicKeys/*}"
+      body: "ssh_public_key"
+    };
+  }
+}
+
+// The user profile information used for logging in to a virtual machine on
+// Google Compute Engine.
+message LoginProfile {
+  // A unique user ID for identifying the user.
+  string name = 1;
+
+  // The list of POSIX accounts associated with the Directory API user.
+  repeated google.cloud.oslogin.common.PosixAccount posix_accounts = 2;
+
+  // A map from SSH public key fingerprint to the associated key object.
+  map<string, google.cloud.oslogin.common.SshPublicKey> ssh_public_keys = 3;
+
+  // Indicates if the user is suspended.
+  bool suspended = 4;
+}
+
+// A request message for deleting a POSIX account entry.
+message DeletePosixAccountRequest {
+  // A reference to the POSIX account to update. POSIX accounts are identified
+  // by the project ID they are associated with. A reference to the POSIX
+  // account is in format `users/{user}/projects/{project}`.
+  string name = 1;
+}
+
+// A request message for deleting an SSH public key.
+message DeleteSshPublicKeyRequest {
+  // The fingerprint of the public key to update. Public keys are identified by
+  // their SHA-256 fingerprint. The fingerprint of the public key is in format
+  // `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1;
+}
+
+// A request message for retrieving the login profile information for a user.
+message GetLoginProfileRequest {
+  // The unique ID for the user in format `users/{user}`.
+  string name = 1;
+}
+
+// A request message for retrieving an SSH public key.
+message GetSshPublicKeyRequest {
+  // The fingerprint of the public key to retrieve. Public keys are identified
+  // by their SHA-256 fingerprint. The fingerprint of the public key is in
+  // format `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1;
+}
+
+// A request message for importing an SSH public key.
+message ImportSshPublicKeyRequest {
+  // The unique ID for the user in format `users/{user}`.
+  string parent = 1;
+
+  // The SSH public key and expiration time.
+  google.cloud.oslogin.common.SshPublicKey ssh_public_key = 2;
+
+  // The project ID of the Google Cloud Platform project.
+  string project_id = 3;
+}
+
+// A response message for importing an SSH public key.
+message ImportSshPublicKeyResponse {
+  // The login profile information for the user.
+  LoginProfile login_profile = 1;
+}
+
+// A request message for updating an SSH public key.
+message UpdateSshPublicKeyRequest {
+  // The fingerprint of the public key to update. Public keys are identified by
+  // their SHA-256 fingerprint. The fingerprint of the public key is in format
+  // `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1;
+
+  // The SSH public key and expiration time.
+  google.cloud.oslogin.common.SshPublicKey ssh_public_key = 2;
+
+  // Mask to control which fields get updated. Updates all if not present.
+  google.protobuf.FieldMask update_mask = 3;
+}

--- a/test/testdata/protos/google/cloud/oslogin/v1beta/oslogin.proto
+++ b/test/testdata/protos/google/cloud/oslogin/v1beta/oslogin.proto
@@ -1,0 +1,208 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.oslogin.v1beta;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/cloud/oslogin/common/common.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option csharp_namespace = "Google.Cloud.OsLogin.V1Beta";
+option go_package = "google.golang.org/genproto/googleapis/cloud/oslogin/v1beta;oslogin";
+option java_multiple_files = true;
+option java_outer_classname = "OsLoginProto";
+option java_package = "com.google.cloud.oslogin.v1beta";
+option php_namespace = "Google\\Cloud\\OsLogin\\V1beta";
+option ruby_package = "Google::Cloud::OsLogin::V1beta";
+
+// Cloud OS Login API
+//
+// The Cloud OS Login API allows you to manage users and their associated SSH
+// public keys for logging into virtual machines on Google Cloud Platform.
+service OsLoginService {
+  option (google.api.default_host) = "oslogin.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform,"
+      "https://www.googleapis.com/auth/cloud-platform.read-only,"
+      "https://www.googleapis.com/auth/compute,"
+      "https://www.googleapis.com/auth/compute.readonly";
+
+  // Deletes a POSIX account.
+  rpc DeletePosixAccount(DeletePosixAccountRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1beta/{name=users/*/projects/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Deletes an SSH public key.
+  rpc DeleteSshPublicKey(DeleteSshPublicKeyRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1beta/{name=users/*/sshPublicKeys/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Retrieves the profile information used for logging in to a virtual machine
+  // on Google Compute Engine.
+  rpc GetLoginProfile(GetLoginProfileRequest) returns (LoginProfile) {
+    option (google.api.http) = {
+      get: "/v1beta/{name=users/*}/loginProfile"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Retrieves an SSH public key.
+  rpc GetSshPublicKey(GetSshPublicKeyRequest) returns (google.cloud.oslogin.common.SshPublicKey) {
+    option (google.api.http) = {
+      get: "/v1beta/{name=users/*/sshPublicKeys/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Adds an SSH public key and returns the profile information. Default POSIX
+  // account information is set when no username and UID exist as part of the
+  // login profile.
+  rpc ImportSshPublicKey(ImportSshPublicKeyRequest) returns (ImportSshPublicKeyResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{parent=users/*}:importSshPublicKey"
+      body: "ssh_public_key"
+    };
+    option (google.api.method_signature) = "parent,ssh_public_key";
+    option (google.api.method_signature) = "parent,ssh_public_key,project_id";
+  }
+
+  // Updates an SSH public key and returns the profile information. This method
+  // supports patch semantics.
+  rpc UpdateSshPublicKey(UpdateSshPublicKeyRequest) returns (google.cloud.oslogin.common.SshPublicKey) {
+    option (google.api.http) = {
+      patch: "/v1beta/{name=users/*/sshPublicKeys/*}"
+      body: "ssh_public_key"
+    };
+    option (google.api.method_signature) = "name,ssh_public_key";
+    option (google.api.method_signature) = "name,ssh_public_key,update_mask";
+  }
+}
+
+// The user profile information used for logging in to a virtual machine on
+// Google Compute Engine.
+message LoginProfile {
+  // Required. A unique user ID.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of POSIX accounts associated with the user.
+  repeated google.cloud.oslogin.common.PosixAccount posix_accounts = 2;
+
+  // A map from SSH public key fingerprint to the associated key object.
+  map<string, google.cloud.oslogin.common.SshPublicKey> ssh_public_keys = 3;
+}
+
+// A request message for deleting a POSIX account entry.
+message DeletePosixAccountRequest {
+  // Required. A reference to the POSIX account to update. POSIX accounts are identified
+  // by the project ID they are associated with. A reference to the POSIX
+  // account is in format `users/{user}/projects/{project}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/PosixAccount"
+    }
+  ];
+}
+
+// A request message for deleting an SSH public key.
+message DeleteSshPublicKeyRequest {
+  // Required. The fingerprint of the public key to update. Public keys are identified by
+  // their SHA-256 fingerprint. The fingerprint of the public key is in format
+  // `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+}
+
+// A request message for retrieving the login profile information for a user.
+message GetLoginProfileRequest {
+  // Required. The unique ID for the user in format `users/{user}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "oslogin.googleapis.com/User"];
+
+  // The project ID of the Google Cloud Platform project.
+  string project_id = 2;
+
+  // A system ID for filtering the results of the request.
+  string system_id = 3;
+}
+
+// A request message for retrieving an SSH public key.
+message GetSshPublicKeyRequest {
+  // Required. The fingerprint of the public key to retrieve. Public keys are identified
+  // by their SHA-256 fingerprint. The fingerprint of the public key is in
+  // format `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+}
+
+// A request message for importing an SSH public key.
+message ImportSshPublicKeyRequest {
+  // The unique ID for the user in format `users/{user}`.
+  string parent = 1 [(google.api.resource_reference) = {
+                       child_type: "oslogin.googleapis.com/SshPublicKey"
+                     }];
+
+  // Required. The SSH public key and expiration time.
+  google.cloud.oslogin.common.SshPublicKey ssh_public_key = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The project ID of the Google Cloud Platform project.
+  string project_id = 3;
+}
+
+// A response message for importing an SSH public key.
+message ImportSshPublicKeyResponse {
+  // The login profile information for the user.
+  LoginProfile login_profile = 1;
+}
+
+// A request message for updating an SSH public key.
+message UpdateSshPublicKeyRequest {
+  // Required. The fingerprint of the public key to update. Public keys are identified by
+  // their SHA-256 fingerprint. The fingerprint of the public key is in format
+  // `users/{user}/sshPublicKeys/{fingerprint}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "oslogin.googleapis.com/SshPublicKey"
+    }
+  ];
+
+  // Required. The SSH public key and expiration time.
+  google.cloud.oslogin.common.SshPublicKey ssh_public_key = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Mask to control which fields get updated. Updates all if not present.
+  google.protobuf.FieldMask update_mask = 3;
+}


### PR DESCRIPTION
`oslogin` API is defined in two directories, `v1` and `common`, `v1alpha` and `v1beta` are the comparison APIs. While adding tests, there need to be some fixes which will be coming in the next PRs.