### PR TITLE
feat: add LRO annotation checking and skip google.longrunning.operations.proto

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -503,9 +503,16 @@ class Method:
     @property
     def lro_annotation(self):
         """Return the LRO operation_info annotation defined for this method."""
-        if not self.output.value.endswith("google.longrunning.Operation"):
+        # Skip the operations.proto because the `GetOperation` does not have LRO annotations.
+        if not self.output.value.endswith("google.longrunning.Operation") or self.proto_file_name == "google/longrunning/operations.proto":
             return None
         op = self.method_pb.options.Extensions[operations_pb2.operation_info]
+        if not op.response_type or not op.metadata_type:
+            raise TypeError(
+                f"rpc {self.name} returns a google.longrunning."
+                "Operation, but is missing a response type or "
+                "metadata type.",
+            )
         lro_annotation = {
             "response_type": op.response_type,
             "metadata_type": op.metadata_type,

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -504,6 +504,7 @@ class Method:
     def lro_annotation(self):
         """Return the LRO operation_info annotation defined for this method."""
         # Skip the operations.proto because the `GetOperation` does not have LRO annotations.
+        # Remove this condition will fail the service-annotation test in cli integration test.
         if not self.output.value.endswith("google.longrunning.Operation") or self.proto_file_name == "google/longrunning/operations.proto":
             return None
         op = self.method_pb.options.Extensions[operations_pb2.operation_info]

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -203,7 +203,7 @@ class Field:
         return WithLocation(
             required,
             self.source_code_locations,
-            self.path + (8, 1052),
+            self.path + (8, 1052, 0),
         )
         # fmt: on
 

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -172,7 +172,7 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(
                 result.output,
                 "google/cloud/oslogin/v1beta/oslogin.proto L149: The child_type `oslogin.googleapis.com/PosixAccount` and type `oslogin.googleapis.com/User` of resource reference option in field `name` cannot be resolved to the identical resource.\n"
-                + "google/cloud/oslogin/v1beta/oslogin.proto L179: Field behavior of an existing field `ssh_public_key` is changed.\n"
+                + "google/cloud/oslogin/v1beta/oslogin.proto L179: Field behavior of an existing field `ssh_public_key` is changed.\n",
             )
 
 

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -155,6 +155,26 @@ class CliDetectTest(unittest.TestCase):
                 + "enum_v1.proto L5: An Enum `BookType` is removed.\n",
             )
 
+    def test_oslogin_proto(self):
+        with patch("sys.stdout", new=StringIO()):
+            runner = CliRunner()
+            result = runner.invoke(
+                detect,
+                [
+                    "--original_api_definition_dirs=test/testdata/protos/",
+                    "--update_api_definition_dirs=test/testdata/protos/",
+                    "--original_proto_files=test/testdata/protos/google/cloud/oslogin/v1/oslogin.proto",
+                    "--update_proto_files=test/testdata/protos/google/cloud/oslogin/v1beta/oslogin.proto",
+                    "--human_readable_message",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                "google/cloud/oslogin/v1beta/oslogin.proto L149: The child_type `oslogin.googleapis.com/PosixAccount` and type `oslogin.googleapis.com/User` of resource reference option in field `name` cannot be resolved to the identical resource.\n"
+                + "google/cloud/oslogin/v1beta/oslogin.proto L179: Field behavior of an existing field `ssh_public_key` is changed.\n"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This checking was removed in #72 since we found that the rpc `getOperation` method in `google.longrunning.operations.proto` returns `google.longrunning.Operation` but does not have LRO annotations. While for other APIs, we do need this checking, so add it back and skip the checking for operations.proto.