### PR TITLE
feat: change actionable field to change_type

### DIFF
--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -14,7 +14,7 @@
 
 from src.comparator.enum_value_comparator import EnumValueComparator
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType
 from src.comparator.wrappers import Enum
 
 
@@ -38,7 +38,7 @@ class EnumComparator:
                 proto_file_name=self.enum_update.proto_file_name,
                 source_code_line=self.enum_update.source_code_line,
                 message=f"A new Enum `{self.enum_update.name}` is added.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
 
         # 2. If updated EnumDescriptor is None, then the original
@@ -49,7 +49,7 @@ class EnumComparator:
                 proto_file_name=self.enum_original.proto_file_name,
                 source_code_line=self.enum_original.source_code_line,
                 message=f"An Enum `{self.enum_original.name}` is removed.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
 
         # 3. If the EnumDescriptors have the same name, check the values

--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType
 from src.comparator.wrappers import EnumValue
 
 
@@ -36,7 +36,7 @@ class EnumValueComparator:
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,
                 message=f"A new EnumValue `{self.enum_value_update.name}` is added.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
         # 2. If updated EnumValue is None, then the original EnumValue is removed.
         elif self.enum_value_update is None:
@@ -45,7 +45,7 @@ class EnumValueComparator:
                 proto_file_name=self.enum_value_original.proto_file_name,
                 source_code_line=self.enum_value_original.source_code_line,
                 message=f"An EnumValue `{self.enum_value_original.name}` is removed.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
         # 3. If both EnumValueDescriptors are existing, check if the name is changed.
         elif self.enum_value_original.name != self.enum_value_update.name:
@@ -54,5 +54,5 @@ class EnumValueComparator:
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,
                 message=f"Name of the EnumValue is changed from `{self.enum_value_original.name}` to `{self.enum_value_update.name}`.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType
 from src.comparator.wrappers import Field
 
 
@@ -41,7 +41,7 @@ class FieldComparator:
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.source_code_line,
                 message=f"A new field `{self.field_update.name}` is added.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
             return
 
@@ -53,7 +53,7 @@ class FieldComparator:
                 proto_file_name=self.field_original.proto_file_name,
                 source_code_line=self.field_original.source_code_line,
                 message=f"An existing field `{self.field_original.name}` is removed.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
             return
 
@@ -70,7 +70,7 @@ class FieldComparator:
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.source_code_line,
                 message=f"Name of an existing field is changed from `{self.field_original.name}` to `{self.field_update.name}`.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
             return
 
@@ -82,7 +82,7 @@ class FieldComparator:
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.repeated.source_code_line,
                 message=f"Repeated state of an existing field `{self.field_original.name}` is changed.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
         # Field option change from optional to required is breaking.
         if not self.field_original.required.value and self.field_update.required.value:
@@ -91,7 +91,7 @@ class FieldComparator:
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.required.source_code_line,
                 message=f"Field behavior of an existing field `{self.field_original.name}` is changed.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
         # 5. Check the type of the field.
         if self.field_original.proto_type.value != self.field_update.proto_type.value:
@@ -100,7 +100,7 @@ class FieldComparator:
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.proto_type.source_code_line,
                 message=f"Type of an existing field `{self.field_original.name}` is changed from `{self.field_original.proto_type.value}` to `{self.field_update.proto_type.value}`.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
         # If field has the same primitive type, then the type is identical.
         # If field has the same non-primitive type like `TYPE_ENUM`.
@@ -128,7 +128,7 @@ class FieldComparator:
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
                     message=f"Type of an existing field `{self.field_original.name}` is changed from `{self.field_original.type_name.value}` to `{self.field_update.type_name.value}`.",
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
         # 6. Check the oneof_index of the field.
         if self.field_original.oneof != self.field_update.oneof:
@@ -141,7 +141,7 @@ class FieldComparator:
                     proto_file_name=proto_file_name,
                     source_code_line=source_code_line,
                     message=msg,
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
             else:
                 msg = f"An existing field `{self.field_original.name}` is moved into One-of."
@@ -150,7 +150,7 @@ class FieldComparator:
                     proto_file_name=proto_file_name,
                     source_code_line=source_code_line,
                     message=msg,
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
 
         # 6. Check `google.api.resource_reference` annotation.
@@ -169,7 +169,7 @@ class FieldComparator:
                 proto_file_name=field_update.proto_file_name,
                 source_code_line=resource_ref_update.source_code_line,
                 message=f"A resource reference option is added to the field `{field_original.name}`.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
             return
         # Resource annotation is removed, check if it is added as a message resource.
@@ -180,7 +180,7 @@ class FieldComparator:
                     proto_file_name=field_original.proto_file_name,
                     source_code_line=resource_ref_original.source_code_line,
                     message=f"A resource reference option of the field `{field_original.name}` is removed.",
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
             return
         # Resource annotation is both existing in the field for original and update versions.
@@ -269,5 +269,5 @@ class FieldComparator:
                 message=f"The child_type `{child_type}` and type `{parent_type}` of "
                 f"resource reference option in field `{self.field_original.name}` "
                 "cannot be resolved to the identical resource.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )

--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -17,7 +17,7 @@ from src.comparator.message_comparator import DescriptorComparator
 from src.comparator.enum_comparator import EnumComparator
 from src.comparator.wrappers import FileSet
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType
 
 
 class FileSetComparator:
@@ -67,7 +67,7 @@ class FileSetComparator:
                         proto_file_name=classname_option.proto_file_name,
                         source_code_line=classname_option.source_code_line,
                         message=f"An exisiting packaging option `{classname}` for `{option}` is removed.",
-                        actionable=True,
+                        change_type=ChangeType.MAJOR,
                     )
             # Compare the option of language namespace. Minor version updates in consideration.
             else:
@@ -96,7 +96,7 @@ class FileSetComparator:
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
                         message=f"An exisiting packaging option `{original_option_value}` for `{option}` is removed.",
-                        actionable=True,
+                        change_type=ChangeType.MAJOR,
                     )
                 for namespace in set(transformed_option_value_update.keys()) - set(
                     transformed_option_value_original.keys()
@@ -110,7 +110,7 @@ class FileSetComparator:
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
                         message=f"A new packaging option `{original_option_value}` for `{option}` is added.",
-                        actionable=True,
+                        change_type=ChangeType.MAJOR,
                     )
 
     def _compare_services(self, fs_original, fs_update):
@@ -191,7 +191,7 @@ class FileSetComparator:
                         resource_type
                     ].source_code_line,
                     message=f"An existing pattern value of the resource definition `{resource_type}` is removed.",
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
             # An existing pattern value is changed.
             # A new pattern value appended to the pattern list is not consider breaking change.
@@ -206,7 +206,7 @@ class FileSetComparator:
                             resource_type
                         ].source_code_line,
                         message=f"An existing pattern value of the resource definition `{resource_type}` is updated from `{old_pattern}` to `{new_pattern}`.",
-                        actionable=True,
+                        change_type=ChangeType.MAJOR,
                     )
 
         # 2. File-level resource definitions addition.
@@ -216,7 +216,7 @@ class FileSetComparator:
                 proto_file_name=resources_update.types[resource_type].proto_file_name,
                 source_code_line=resources_update.types[resource_type].source_code_line,
                 message=f"A file-level resource definition `{resource_type}` has been added.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
         # 3. File-level resource definitions removal may not be breaking change since
         # the resource could be moved to message-level. This will be checked in the message

--- a/src/comparator/message_comparator.py
+++ b/src/comparator/message_comparator.py
@@ -16,7 +16,7 @@ from src.comparator.field_comparator import FieldComparator
 from src.comparator.enum_comparator import EnumComparator
 from src.comparator.wrappers import Message
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType
 
 
 class DescriptorComparator:
@@ -42,7 +42,7 @@ class DescriptorComparator:
                 proto_file_name=message_update.proto_file_name,
                 source_code_line=message_update.source_code_line,
                 message=f"A new message `{message_update.name}` is added.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
             return
         # 2. If updated message is None, then the original message is removed.
@@ -52,7 +52,7 @@ class DescriptorComparator:
                 proto_file_name=message_original.proto_file_name,
                 source_code_line=message_original.source_code_line,
                 message=f"An existing message `{message_original.name}` is removed.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
             return
 
@@ -154,7 +154,7 @@ class DescriptorComparator:
                 proto_file_name=self.message_update.proto_file_name,
                 source_code_line=resource_update.source_code_line,
                 message=f"A message-level resource definition `{resource_update.value.type}` has been added.",
-                actionable=False,
+                change_type=ChangeType.MINOR,
             )
             return
         # 2. Message-level resource definitions removal may not be breaking change since
@@ -170,7 +170,7 @@ class DescriptorComparator:
                     proto_file_name=self.message_original.proto_file_name,
                     source_code_line=resource_original.source_code_line,
                     message=f"An existing message-level resource definition `{resource_original.value.type}` has been removed.",
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
                 return
             # Check if the removed resource is in the global file-level resource database.
@@ -180,7 +180,7 @@ class DescriptorComparator:
                     proto_file_name=self.message_original.proto_file_name,
                     source_code_line=resource_original.source_code_line,
                     message=f"An existing message-level resource definition `{resource_original.value.type}` has been removed.",
-                    actionable=True,
+                    change_type=ChangeType.MAJOR,
                 )
             else:
                 # Check the patterns of existing file-level resource are compatible with
@@ -199,7 +199,7 @@ class DescriptorComparator:
                         proto_file_name=self.message_original.proto_file_name,
                         source_code_line=resource_original.source_code_line,
                         message=f"An existing message-level resource definition `{resource_original.value.type}` has been removed.",
-                        actionable=True,
+                        change_type=ChangeType.MAJOR,
                     )
             return
         # Resource is existing in both original and update versions.
@@ -212,7 +212,7 @@ class DescriptorComparator:
                 proto_file_name=self.message_update.proto_file_name,
                 source_code_line=resource_update.source_code_line,
                 message=f"The pattern of an existing message-level resource definition `{resource_original.value.type}` has changed from `{resource_original.value.pattern}` to `{resource_update.value.pattern}`.",
-                actionable=True,
+                change_type=ChangeType.MAJOR,
             )
 
     def _compatible_patterns(self, patterns_original, patterns_update):

--- a/src/findings/finding_container.py
+++ b/src/findings/finding_container.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from src.findings.utils import Finding
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType, Finding
 from collections import defaultdict
 
 
@@ -27,7 +26,7 @@ class FindingContainer:
         proto_file_name: str,
         source_code_line: int,
         message: str,
-        actionable: bool,
+        change_type: ChangeType,
         extra_info=None,
     ):
         self.finding_results.append(
@@ -36,7 +35,7 @@ class FindingContainer:
                 proto_file_name,
                 source_code_line,
                 message,
-                actionable,
+                change_type,
                 extra_info,
             )
         )
@@ -45,7 +44,11 @@ class FindingContainer:
         return self.finding_results
 
     def getActionableFindings(self):
-        return [finding for finding in self.finding_results if finding.actionable]
+        return [
+            finding
+            for finding in self.finding_results
+            if finding.change_type == ChangeType.MAJOR
+        ]
 
     def toDictArr(self):
         return [finding.toDict() for finding in self.finding_results]

--- a/src/findings/utils.py
+++ b/src/findings/utils.py
@@ -103,6 +103,6 @@ class Finding:
                 "source_code_line": self.location.source_code_line,
             },
             "message": self.message,
-            "change_type": self.change_type.value,
+            "change_type": self.change_type,
             "extra_info": self.extra_info,
         }

--- a/src/findings/utils.py
+++ b/src/findings/utils.py
@@ -66,6 +66,11 @@ class FindingCategory(enum.Enum):
     FIELD_BEHAVIOR_CHANGE = 44
 
 
+class ChangeType(enum.Enum):
+    MAJOR = 1
+    MINOR = 2
+
+
 class Finding:
     class _Location:
         proto_file_name: str
@@ -81,13 +86,13 @@ class Finding:
         proto_file_name,
         source_code_line,
         message,
-        actionable,
+        change_type,
         extra_info=None,
     ):
         self.category = category
         self.location = self._Location(proto_file_name, source_code_line)
         self.message = message
-        self.actionable = actionable
+        self.change_type = change_type
         self.extra_info = extra_info
 
     def toDict(self):
@@ -98,6 +103,6 @@ class Finding:
                 "source_code_line": self.location.source_code_line,
             },
             "message": self.message,
-            "actionable": self.actionable,
+            "change_type": self.change_type.value,
             "extra_info": self.extra_info,
         }

--- a/src/findings/utils.py
+++ b/src/findings/utils.py
@@ -103,6 +103,6 @@ class Finding:
                 "source_code_line": self.location.source_code_line,
             },
             "message": self.message,
-            "change_type": self.change_type,
+            "change_type": self.change_type.name,
             "extra_info": self.extra_info,
         }

--- a/test/comparator/test_resources.py
+++ b/test/comparator/test_resources.py
@@ -107,7 +107,7 @@ class ResourceReferenceTest(unittest.TestCase):
             "resource_database_v1.proto",
         )
         self.assertEqual(message_resource_removal.location.source_code_line, 34)
-        self.assertEqual(message_resource_removal.actionable, True)
+        self.assertEqual(message_resource_removal.change_type.value, 1)
 
     def test_resource_reference_change(self):
         _INVOKER_ORIGNAL = Loader(

--- a/test/findings/test_finding_container.py
+++ b/test/findings/test_finding_container.py
@@ -14,7 +14,7 @@
 
 import unittest
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory
+from src.findings.utils import FindingCategory, ChangeType
 
 
 class FindingContainerTest(unittest.TestCase):
@@ -30,7 +30,7 @@ class FindingContainerTest(unittest.TestCase):
             proto_file_name="my_proto.proto",
             source_code_line=12,
             message="An rpc method bar is removed.",
-            actionable=True,
+            change_type=ChangeType.MAJOR,
         )
         self.assertEqual(len(self.finding_container.getAllFindings()), 1)
 
@@ -40,7 +40,7 @@ class FindingContainerTest(unittest.TestCase):
             proto_file_name="my_proto.proto",
             source_code_line=15,
             message="Not breaking change.",
-            actionable=False,
+            change_type=ChangeType.MINOR,
         )
         self.assertEqual(len(self.finding_container.getActionableFindings()), 1)
 
@@ -55,14 +55,14 @@ class FindingContainerTest(unittest.TestCase):
             proto_file_name="my_proto.proto",
             source_code_line=5,
             message="An existing file-level resource definition has changed.",
-            actionable=True,
+            change_type=ChangeType.MAJOR,
         )
         self.finding_container.addFinding(
             category=FindingCategory.METHOD_SIGNATURE_CHANGE,
             proto_file_name="my_other_proto.proto",
             source_code_line=16,
             message="An existing method_signature is changed from 'sig1' to 'sig2'.",
-            actionable=True,
+            change_type=ChangeType.MAJOR,
         )
         self.assertEqual(
             self.finding_container.toHumanReadableMessage(),


### PR DESCRIPTION
For external users, it is clearer to use "major" and "minor" change to identify the detected change is "breaking " or "not breaking".