### PR TITLE
fix: create global messages map

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -725,7 +725,9 @@ class FileSet:
         source_code_locations_map = self._get_source_code_locations_map()
         # Register all resources in the database.
         self.resources_database = self._get_resource_database(source_code_locations_map)
+        # Get API version from definition files.
         self.api_version = self._get_api_version()
+        # Get all messages in the map.
         self.messages_map = self._get_messages_map(source_code_locations_map)
 
         self.packaging_options_map = defaultdict(dict)


### PR DESCRIPTION
The Service class needs the messages map to query the input/output type of the methods. Originally we iterate the file set and update the message map along creating the service objects, while it does not work when the used message type is defined in the unvisited file. So we need to create the global messages before constructing the service objects.