### PR TITLE
fix: fix field number for packaging option

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -906,8 +906,8 @@ class FileSet:
         packaging_options_path = {
             "java_package": (1,),
             "java_outer_classname": (8,),
-            "csharp_namespace": (11,),
-            "go_package": (37,),
+            "csharp_namespace": (37,),
+            "go_package": (11,),
             "swift_prefix": (39,),
             "php_namespace": (41,),
             "php_metadata_namespace": (44,),

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -219,7 +219,10 @@ class FileSetTest(unittest.TestCase):
             file_set.packaging_options_map["java_package"][
                 "com.google.example.v1"
             ].path,
-            (8, 1,),
+            (
+                8,
+                1,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["php_namespace"].keys()),
@@ -229,23 +232,28 @@ class FileSetTest(unittest.TestCase):
             file_set.packaging_options_map["php_namespace"][
                 "Google\\Cloud\\Example\\V1"
             ].path,
-            (8, 41,),
+            (
+                8,
+                41,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["java_outer_classname"].keys()),
             ["Foo", "Bar"],
         )
         self.assertEqual(
-            file_set.packaging_options_map["java_outer_classname"][
-                "Foo"
-            ].path,
-            (8, 8,),
+            file_set.packaging_options_map["java_outer_classname"]["Foo"].path,
+            (
+                8,
+                8,
+            ),
         )
         self.assertEqual(
-            file_set.packaging_options_map["java_outer_classname"][
-                "Bar"
-            ].path,
-            (8, 8,),
+            file_set.packaging_options_map["java_outer_classname"]["Bar"].path,
+            (
+                8,
+                8,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["php_metadata_namespace"].keys()),
@@ -255,57 +263,65 @@ class FileSetTest(unittest.TestCase):
             file_set.packaging_options_map["php_metadata_namespace"][
                 "php_metadata_namespace"
             ].path,
-            (8, 44,),
+            (
+                8,
+                44,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["php_class_prefix"].keys()),
             ["php_class_prefix"],
         )
         self.assertEqual(
-            file_set.packaging_options_map["php_class_prefix"][
-                "php_class_prefix"
-            ].path,
-            (8, 40,),
+            file_set.packaging_options_map["php_class_prefix"]["php_class_prefix"].path,
+            (
+                8,
+                40,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["ruby_package"].keys()),
             ["ruby_package"],
         )
         self.assertEqual(
-            file_set.packaging_options_map["ruby_package"][
-                "ruby_package"
-            ].path,
-            (8, 45,),
+            file_set.packaging_options_map["ruby_package"]["ruby_package"].path,
+            (
+                8,
+                45,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["go_package"].keys()),
             ["go_package"],
         )
         self.assertEqual(
-            file_set.packaging_options_map["go_package"][
-                "go_package"
-            ].path,
-            (8, 11,),
+            file_set.packaging_options_map["go_package"]["go_package"].path,
+            (
+                8,
+                11,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["csharp_namespace"].keys()),
             ["csharp_namespace"],
         )
         self.assertEqual(
-            file_set.packaging_options_map["csharp_namespace"][
-                "csharp_namespace"
-            ].path,
-            (8, 37,),
+            file_set.packaging_options_map["csharp_namespace"]["csharp_namespace"].path,
+            (
+                8,
+                37,
+            ),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["swift_prefix"].keys()),
             ["swift_prefix"],
         )
         self.assertEqual(
-            file_set.packaging_options_map["swift_prefix"][
-                "swift_prefix"
-            ].path,
-            (8, 39,),
+            file_set.packaging_options_map["swift_prefix"]["swift_prefix"].path,
+            (
+                8,
+                39,
+            ),
         )
 
     def test_file_set_api_version(self):

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -195,7 +195,14 @@ class FileSetTest(unittest.TestCase):
         option1 = descriptor_pb2.FileOptions()
         option1.java_package = "com.google.example.v1"
         option1.php_namespace = "Google\\Cloud\\Example\\V1"
+        option1.php_metadata_namespace = "php_metadata_namespace"
+        option1.php_class_prefix = "php_class_prefix"
+        option1.ruby_package = "ruby_package"
         option1.java_outer_classname = "Foo"
+        option1.go_package = "go_package"
+        option1.csharp_namespace = "csharp_namespace"
+        option1.swift_prefix = "swift_prefix"
+
         option2 = descriptor_pb2.FileOptions()
         option2.java_outer_classname = "Bar"
         # Two proto files have the same packging options.
@@ -209,12 +216,96 @@ class FileSetTest(unittest.TestCase):
             ["com.google.example.v1"],
         )
         self.assertEqual(
+            file_set.packaging_options_map["java_package"][
+                "com.google.example.v1"
+            ].path,
+            (8, 1,),
+        )
+        self.assertEqual(
             list(file_set.packaging_options_map["php_namespace"].keys()),
             ["Google\\Cloud\\Example\\V1"],
         )
         self.assertEqual(
+            file_set.packaging_options_map["php_namespace"][
+                "Google\\Cloud\\Example\\V1"
+            ].path,
+            (8, 41,),
+        )
+        self.assertEqual(
             list(file_set.packaging_options_map["java_outer_classname"].keys()),
             ["Foo", "Bar"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["java_outer_classname"][
+                "Foo"
+            ].path,
+            (8, 8,),
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["java_outer_classname"][
+                "Bar"
+            ].path,
+            (8, 8,),
+        )
+        self.assertEqual(
+            list(file_set.packaging_options_map["php_metadata_namespace"].keys()),
+            ["php_metadata_namespace"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["php_metadata_namespace"][
+                "php_metadata_namespace"
+            ].path,
+            (8, 44,),
+        )
+        self.assertEqual(
+            list(file_set.packaging_options_map["php_class_prefix"].keys()),
+            ["php_class_prefix"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["php_class_prefix"][
+                "php_class_prefix"
+            ].path,
+            (8, 40,),
+        )
+        self.assertEqual(
+            list(file_set.packaging_options_map["ruby_package"].keys()),
+            ["ruby_package"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["ruby_package"][
+                "ruby_package"
+            ].path,
+            (8, 45,),
+        )
+        self.assertEqual(
+            list(file_set.packaging_options_map["go_package"].keys()),
+            ["go_package"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["go_package"][
+                "go_package"
+            ].path,
+            (8, 11,),
+        )
+        self.assertEqual(
+            list(file_set.packaging_options_map["csharp_namespace"].keys()),
+            ["csharp_namespace"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["csharp_namespace"][
+                "csharp_namespace"
+            ].path,
+            (8, 37,),
+        )
+        self.assertEqual(
+            list(file_set.packaging_options_map["swift_prefix"].keys()),
+            ["swift_prefix"],
+        )
+        self.assertEqual(
+            file_set.packaging_options_map["swift_prefix"][
+                "swift_prefix"
+            ].path,
+            (8, 39,),
         )
 
     def test_file_set_api_version(self):

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -210,7 +210,7 @@ class FileSetTest(unittest.TestCase):
         file2 = make_file_pb2(name="proto2", options=option2)
         file_set = make_file_set(files=[file1, file2])
         self.assertTrue(file_set.packaging_options_map)
-
+        # fmt: off
         self.assertEqual(
             list(file_set.packaging_options_map["java_package"].keys()),
             ["com.google.example.v1"],
@@ -218,11 +218,7 @@ class FileSetTest(unittest.TestCase):
         self.assertEqual(
             file_set.packaging_options_map["java_package"][
                 "com.google.example.v1"
-            ].path,
-            (
-                8,
-                1,
-            ),
+            ].path, (8, 1,),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["php_namespace"].keys()),
@@ -231,11 +227,7 @@ class FileSetTest(unittest.TestCase):
         self.assertEqual(
             file_set.packaging_options_map["php_namespace"][
                 "Google\\Cloud\\Example\\V1"
-            ].path,
-            (
-                8,
-                41,
-            ),
+            ].path, (8, 41,),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["java_outer_classname"].keys()),
@@ -243,17 +235,11 @@ class FileSetTest(unittest.TestCase):
         )
         self.assertEqual(
             file_set.packaging_options_map["java_outer_classname"]["Foo"].path,
-            (
-                8,
-                8,
-            ),
+            (8, 8),
         )
         self.assertEqual(
             file_set.packaging_options_map["java_outer_classname"]["Bar"].path,
-            (
-                8,
-                8,
-            ),
+            (8, 8),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["php_metadata_namespace"].keys()),
@@ -263,10 +249,7 @@ class FileSetTest(unittest.TestCase):
             file_set.packaging_options_map["php_metadata_namespace"][
                 "php_metadata_namespace"
             ].path,
-            (
-                8,
-                44,
-            ),
+            (8, 44),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["php_class_prefix"].keys()),
@@ -274,10 +257,7 @@ class FileSetTest(unittest.TestCase):
         )
         self.assertEqual(
             file_set.packaging_options_map["php_class_prefix"]["php_class_prefix"].path,
-            (
-                8,
-                40,
-            ),
+            (8, 40),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["ruby_package"].keys()),
@@ -285,10 +265,7 @@ class FileSetTest(unittest.TestCase):
         )
         self.assertEqual(
             file_set.packaging_options_map["ruby_package"]["ruby_package"].path,
-            (
-                8,
-                45,
-            ),
+            (8, 45),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["go_package"].keys()),
@@ -296,10 +273,7 @@ class FileSetTest(unittest.TestCase):
         )
         self.assertEqual(
             file_set.packaging_options_map["go_package"]["go_package"].path,
-            (
-                8,
-                11,
-            ),
+            (8, 11),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["csharp_namespace"].keys()),
@@ -307,10 +281,7 @@ class FileSetTest(unittest.TestCase):
         )
         self.assertEqual(
             file_set.packaging_options_map["csharp_namespace"]["csharp_namespace"].path,
-            (
-                8,
-                37,
-            ),
+            (8, 37),
         )
         self.assertEqual(
             list(file_set.packaging_options_map["swift_prefix"].keys()),
@@ -318,11 +289,9 @@ class FileSetTest(unittest.TestCase):
         )
         self.assertEqual(
             file_set.packaging_options_map["swift_prefix"]["swift_prefix"].path,
-            (
-                8,
-                39,
-            ),
+            (8, 39),
         )
+        # fmt: on
 
     def test_file_set_api_version(self):
         dep1 = make_file_pb2(name="dep1", package=".example.external")


### PR DESCRIPTION
By testing pubsub protos, the field number for packaging options `csharp_namespace` and `go_package` is switched. Added unit tests to cover the source code locations.
ref: [go_package](https://source.corp.google.com/piper///depot/google3/net/proto2/proto/descriptor.proto;l=534;bpv=0;bpt=1) [csharp_namespace](https://source.corp.google.com/piper///depot/google3/net/proto2/proto/descriptor.proto;l=601;bpv=0;bpt=1)