### PR TITLE
feat [1/3]: add map entry type to field

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -255,18 +255,14 @@ class Field:
 
     @property
     def map_entry_type(self):
+        # Get the key and value type for the map entry.
+        def get_type(name):
+            field = self.map_entry[name]
+            return (
+                field.proto_type.value if field.is_primitive_type else field.type_name.value
+            )
         if self.is_map_type:
-            key_type = (
-                self.map_entry["key"].proto_type.value
-                if self.map_entry["key"].is_primitive_type
-                else self.map_entry["key"].type_name.value
-            )
-            value_type = (
-                self.map_entry["value"].proto_type.value
-                if self.map_entry["value"].is_primitive_type
-                else self.map_entry["value"].type_name.value
-            )
-            return {"key": key_type, "value": value_type}
+            return {name: get_type(name) for name in ("key", "value")}
         return None
 
     @property

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -292,7 +292,7 @@ class Message:
                            and message-level resource options.
     api_version: the version of the API definition files.
     map: whether the message is an automatically generated map entry type for the maps field.
-        
+
         For maps fields:
         map<KeyType, ValueType> map_field = 1;
         The parsed descriptor looks like:
@@ -423,7 +423,7 @@ class Message:
             self.path + (7, 1053),
             self.proto_file_name,
         )
-    
+
     @property
     def map(self) -> bool:
         return self.message_pb.options.map_entry

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -259,8 +259,11 @@ class Field:
         def get_type(name):
             field = self.map_entry[name]
             return (
-                field.proto_type.value if field.is_primitive_type else field.type_name.value
+                field.proto_type.value
+                if field.is_primitive_type
+                else field.type_name.value
             )
+
         if self.is_map_type:
             return {name: get_type(name) for name in ("key", "value")}
         return None
@@ -412,7 +415,7 @@ class Message:
         for message in self.message_pb.nested_type:
             if message.options.map_entry:
                 fields = {field.name: field for field in message.field}
-                if not fields["key"] or not fields["value"]:
+                if not {"key", "value"} <= fields.keys():
                     raise TypeError(
                         "The auto-generated map entry message should have key and value fields."
                     )

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -150,7 +150,7 @@ class Field:
         resource_database: ResourceDatabase = None,
         message_resource: resource_pb2.ResourceDescriptor = None,
         api_version: str = None,
-        map_entry = None,
+        map_entry=None,
     ):
 
         self.field_pb = field_pb

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -468,10 +468,6 @@ class Message:
         )
 
     @property
-    def map(self) -> bool:
-        return self.message_pb.options.map_entry
-
-    @property
     def source_code_line(self):
         """Return the start line number of Message definition in the proto file."""
         return _get_source_code_line(self.source_code_locations, self.path)

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -150,7 +150,7 @@ class Field:
         resource_database: ResourceDatabase = None,
         message_resource: resource_pb2.ResourceDescriptor = None,
         api_version: str = None,
-        map_entry: Dict[str, Field] = None,
+        map_entry = None,
     ):
 
         self.field_pb = field_pb
@@ -236,7 +236,7 @@ class Field:
     @property
     def is_map_type(self):
         """Return true if the field is map type."""
-        return not self.map_entry
+        return self.map_entry
 
     @property
     def type_name(self):
@@ -257,14 +257,14 @@ class Field:
     def map_entry_type(self):
         if self.is_map_type:
             key_type = (
-                self.map_entry["key"].proto_type
+                self.map_entry["key"].proto_type.value
                 if self.map_entry["key"].is_primitive_type
-                else self.map_entry["key"].type_name
+                else self.map_entry["key"].type_name.value
             )
             value_type = (
-                self.map_entry["value"].proto_type
+                self.map_entry["value"].proto_type.value
                 if self.map_entry["value"].is_primitive_type
-                else self.map_entry["value"].type_name
+                else self.map_entry["value"].type_name.value
             )
             return {"key": key_type, "value": value_type}
 
@@ -364,7 +364,7 @@ class Message:
                 field_pb=field,
                 proto_file_name=self.proto_file_name,
                 source_code_locations=self.source_code_locations,
-                path=path,
+                path=self.path + (2, i),
                 resource_database=self.resource_database,
                 message_resource=self.resource,
                 api_version=self.api_version,

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -15,7 +15,7 @@
 import unittest
 import os
 from src.detector.loader import Loader
-from src.comparator.wrappers import FileSet
+from src.comparator.wrappers import FileSet, Field
 
 
 class WrappersTest(unittest.TestCase):
@@ -122,6 +122,16 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(resource.value.pattern, ["foo/{foo}/bar/{bar}"])
         self.assertEqual(resource.value.type, "example.googleapis.com/Foo")
 
+        # The message has auto-generated map entries (nested type) for fields that is map type.
+        map_message = messages_map["MapMessage"]
+        self.assertEqual(len(map_message.fields.keys()), 1)
+        self.assertEqual(map_message.fields[1].name, "first_field")
+        self.assertEqual(list(map_message.map_entries.keys()), ["FirstFieldEntry"])
+        self.assertTrue(isinstance(map_message.map_entries["FirstFieldEntry"]["key"], Field))
+        self.assertTrue(isinstance(map_message.map_entries["FirstFieldEntry"]["value"], Field))
+        # It should not put into the nested message, so the nested message map is empty.
+        self.assertFalse(map_message.nested_messages)
+
     def test_field_wrapper(self):
         foo_response_message = self._FILE_SET.messages_map["FooResponse"]
         enum_field = foo_response_message.fields[1]
@@ -146,6 +156,12 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(name_field.name, "name")
         self.assertFalse(name_field.repeated.value)
         self.assertTrue(name_field.required.value)
+
+        map_field = self._FILE_SET.messages_map["MapMessage"].fields[1]
+        self.assertTrue(map_field.map_entry)
+        self.assertTrue(map_field.is_map_type)
+        self.assertEqual(map_field.map_entry_type["key"], "TYPE_STRING")
+        self.assertEqual(map_field.map_entry_type["value"], ".example.v1alpha.FooMetadata")
 
     def test_enum_wrapper(self):
         enum = self._FILE_SET.enums_map["Enum1"]

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -127,8 +127,12 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(len(map_message.fields.keys()), 1)
         self.assertEqual(map_message.fields[1].name, "first_field")
         self.assertEqual(list(map_message.map_entries.keys()), ["FirstFieldEntry"])
-        self.assertTrue(isinstance(map_message.map_entries["FirstFieldEntry"]["key"], Field))
-        self.assertTrue(isinstance(map_message.map_entries["FirstFieldEntry"]["value"], Field))
+        self.assertTrue(
+            isinstance(map_message.map_entries["FirstFieldEntry"]["key"], Field)
+        )
+        self.assertTrue(
+            isinstance(map_message.map_entries["FirstFieldEntry"]["value"], Field)
+        )
         # It should not put into the nested message, so the nested message map is empty.
         self.assertFalse(map_message.nested_messages)
 
@@ -161,7 +165,9 @@ class WrappersTest(unittest.TestCase):
         self.assertTrue(map_field.map_entry)
         self.assertTrue(map_field.is_map_type)
         self.assertEqual(map_field.map_entry_type["key"], "TYPE_STRING")
-        self.assertEqual(map_field.map_entry_type["value"], ".example.v1alpha.FooMetadata")
+        self.assertEqual(
+            map_field.map_entry_type["value"], ".example.v1alpha.FooMetadata"
+        )
 
     def test_enum_wrapper(self):
         enum = self._FILE_SET.enums_map["Enum1"]

--- a/test/testdata/protos/example/wrappers.proto
+++ b/test/testdata/protos/example/wrappers.proto
@@ -72,3 +72,7 @@ enum Enum1 {
   b = 1;
 }
 
+message MapMessage {
+  map<string, FooMetadata> first_field = 1;
+}
+


### PR DESCRIPTION
By testing pubsub proto, I found that if a field is map<keyType, valueType> type, a nested message will be auto-generated to indicate the key type and value type. For example:
```
# For map field in message:
message MapMessage {
  map<string, FooMetadata> first_field = 1;
}

# The parsed descriptor looks like:
message MapMessage {
     message FirstFieldEntry{
            option map_entry = true;
            optional string key = 1;
            optional FooMetadata value = 2;
     }
     repeated FirstFieldEntry first_field = 1;
}
```

So from a message, we create a map_entries map for these auto-generated nested message (`FirstFieldEntry`), whose `map_entry`  option is true. The key is the nested message name (`FirstFieldEntry`) and the value is a map {"key": keyField, "value": valueField}.
From a field, we add one attribute called `map_entry`, if it is not None, it means that this field is map type. We will then look at the the key and value of the map_entry to determine the types.

Tested the attributes in the real `wrappers.proto`. Unit tests will come as next PR.