### PR TITLE
feat [1]: get API definition files from file set

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -821,7 +821,9 @@ class FileSet:
         )
         # Get API definition files. This helps us to compare only the definition files
         # and imported dependency information.
-        self.definition_files = [f for f in file_set_pb.file if f.package == self.root_package]
+        self.definition_files = [
+            f for f in file_set_pb.file if f.package == self.root_package
+        ]
         # Get all messages in the map.
         self.messages_map = self._get_messages_map(source_code_locations_map)
 
@@ -890,7 +892,7 @@ class FileSet:
             )
         return messages_map
 
-    def _get_root_package(self) -> Optional[str]:
+    def _get_root_package(self) -> str:
         dependency_map: Dict[str, Sequence[str]] = defaultdict(list)
         for fd in self.file_set_pb.file:
             # Put the fileDescriptor and its dependencies to the dependency map.
@@ -900,10 +902,8 @@ class FileSet:
         for f, deps in dependency_map.items():
             for dep in deps:
                 if dep.name not in dependency_map:
-                    # match = re.search(version, dep.package)
                     return dep.package
         return self.file_set_pb.file[0].package
-        # return re.search(version, package).group()
 
     def _get_source_code_locations_map(
         self,

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -52,6 +52,9 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(
             list(self._FILE_SET.services_map.keys()), ["Operations", "Example"]
         )
+        self.assertEqual(self._FILE_SET.root_package, "example.v1alpha")
+        self.assertEqual(len(self._FILE_SET.definition_files), 1)
+        self.assertEqual(self._FILE_SET.definition_files[0].name, "wrappers.proto")
         self.assertEqual(self._FILE_SET.api_version, "v1alpha")
 
     def test_service_wrapper(self):

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -306,7 +306,6 @@ class FileSetTest(unittest.TestCase):
         file_set = make_file_set(files=[file1, file2, dep1, dep2])
         self.assertEqual(file_set.api_version, "v1beta")
 
-
     def test_file_set_root_package(self):
         dep1 = make_file_pb2(name="dep1", package="example.external")
         dep2 = make_file_pb2(name="dep2", package="example.external")
@@ -324,7 +323,9 @@ class FileSetTest(unittest.TestCase):
         # The package name `example.tutorial` does not have any match for a version.
         self.assertFalse(file_set.api_version)
         # The `proto2` and `proto3` are API definition files, others are dependencies.
-        self.assertEqual([f.name for f in file_set.definition_files], ["proto2", "proto3"])
+        self.assertEqual(
+            [f.name for f in file_set.definition_files], ["proto2", "proto3"]
+        )
         # If the files are totally not related, the root_package will be the first file package.
         file_set = make_file_set(files=[dep1, dep2])
         self.assertEqual(file_set.root_package, "example.external")


### PR DESCRIPTION
Currently we compare all messages, services and enums in the file set including dependencies, while it will give extra output breaking change messages. 

For example: `dep1` file is no longer imported for the updated versions, then every messages, enums in that file will be marked as removal which are breaking changes. While we actually only need the messages/enums used in the definition files, if they are totally unused, then the comparison is redundant.

So we want to compare only the used information from the dependency files, the whole implementation split into several steps: 
1) Get root_package and api_version, so that we can determine the API definition files, all the others in file set are dependencies. [this PR]
2) Create `global_messages_map` and `global_enums_map` to have all messages/enums (including the nested messages/enums since they could also be referenced) registered from file set. Key is the full name of the message/enum, for example: `.example.v1.message`, `.example.v1.message.enum`, value would be the Message/Enum class object defined in the `wrappers`.
3) Create `used_messages_map`, `used_services_map` and `used_enums_map` for comparison in file_set comparator.
    - `used_services_map` includes the services defined in the API definition files.
    - `used_enums_map` includes the enums defined in the API definition files.
    - `used_messages_map` includes a) the first level messages defined in the API definition files. b) for fields/nested fields, the 
                                                                    message type of the fields if they are not primitive type; If the fields are map type, the 
                                                                    message type is auto-generated, so we have to look at the key, value type of the fields.
                                                                 c) for methods in services, the input_type and output_type should also be put in the map.
                                        

