### PR TITLE
feat [2]: create global messages and enums map

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -832,7 +832,7 @@ class FileSet:
         ]
         # Create global messages/enums map to have all messages/enums registered from the file
         # set including the nested messages/enums, since they could also be referenced.
-        # Key is the full name of the message and value if the Message object.
+        # Key is the full name of the message/enum and value is the Message/Enum object.
         self._get_global_info_map(source_code_locations_map)
         # Get all messages in the map.
         # TODO(xiaozhenliu): update the map when global messages map is in place.
@@ -894,7 +894,7 @@ class FileSet:
                     proto_file_name=fd.name,
                     source_code_locations=source_code_locations,
                     path=(5, i),
-                    full_name=self._get_full_name(fd.package, enum.name),
+                    full_name=full_name,
                 )
             # Register first level messages.
             message_stack = [

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -821,7 +821,9 @@ class FileSet:
         )
         # Get API definition files. This helps us to compare only the definition files
         # and imported dependency information.
-        self.definition_files = [f for f in file_set_pb.file if f.package == self.root_package]
+        self.definition_files = [
+            f for f in file_set_pb.file if f.package == self.root_package
+        ]
         # Get all messages in the map.
         self.messages_map = self._get_messages_map(source_code_locations_map)
 
@@ -890,7 +892,7 @@ class FileSet:
             )
         return messages_map
 
-    def _get_root_package(self) -> Optional[str]:
+    def _get_root_package(self) -> str:
         dependency_map: Dict[str, Sequence[str]] = defaultdict(list)
         for fd in self.file_set_pb.file:
             # Put the fileDescriptor and its dependencies to the dependency map.
@@ -900,10 +902,8 @@ class FileSet:
         for f, deps in dependency_map.items():
             for dep in deps:
                 if dep.name not in dependency_map:
-                    # match = re.search(version, dep.package)
                     return dep.package
         return self.file_set_pb.file[0].package
-        # return re.search(version, package).group()
 
     def _get_source_code_locations_map(
         self,

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -873,7 +873,7 @@ class FileSet:
                         fd.name,
                         source_code_locations,
                         path + (5, i,),
-                        self._get_full_message_name(fd.package, enum.name),
+                        self._get_full_name(fd.package, enum.name),
                     ),
                 )
                 for i, enum in enumerate(fd.enum_type)
@@ -886,18 +886,15 @@ class FileSet:
         for fd in self.file_set_pb.file:
             source_code_locations = source_code_locations_map[fd.name]
             # Register first level enums.
+            # fmt: off
             for i, enum in enumerate(fd.enum_type):
-                self.global_enums_map[
-                    self._get_full_message_name(fd.package, enum.name)
-                ] = Enum(
+                full_name = self._get_full_name(fd.package, enum.name)
+                self.global_enums_map[full_name] = Enum(
                     enum_pb=enum,
                     proto_file_name=fd.name,
                     source_code_locations=source_code_locations,
-                    path=(
-                        5,
-                        i,
-                    ),
-                    full_name=self._get_full_message_name(fd.package, enum.name),
+                    path=(5, i),
+                    full_name=self._get_full_name(fd.package, enum.name),
                 )
             # Register first level messages.
             message_stack = [
@@ -905,17 +902,15 @@ class FileSet:
                     message_pb=message,
                     proto_file_name=fd.name,
                     source_code_locations=source_code_locations,
-                    path=(
-                        4,
-                        i,
-                    ),
+                    path=(4, i),
                     resource_database=self.resources_database,
                     api_version=self.api_version,
                     # `.package.outer_message.nested_message`
-                    full_name=self._get_full_message_name(fd.package, message.name),
+                    full_name=self._get_full_name(fd.package, message.name),
                 )
                 for i, message in enumerate(fd.message_type)
             ]
+            # fmt: on
             # Iterate for nested messages and enums.
             while message_stack:
                 message = message_stack.pop()
@@ -943,7 +938,7 @@ class FileSet:
                         ),
                         self.resources_database,
                         self.api_version,
-                        self._get_full_message_name(fd.package, message.name),
+                        self._get_full_name(fd.package, message.name),
                     ),
                 )
                 for i, message in enumerate(fd.message_type)
@@ -1078,5 +1073,5 @@ class FileSet:
                     proto_file_name,
                 )
 
-    def _get_full_message_name(self, package_name, name) -> str:
+    def _get_full_name(self, package_name, name) -> str:
         return "." + package_name + "." + name

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -56,6 +56,46 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(len(self._FILE_SET.definition_files), 1)
         self.assertEqual(self._FILE_SET.definition_files[0].name, "wrappers.proto")
         self.assertEqual(self._FILE_SET.api_version, "v1alpha")
+        # Check the global messages/enums map
+        self.assertEqual(
+            [
+                message_name
+                for message_name in self._FILE_SET.global_messages_map.keys()
+                if message_name.startswith(".example.v1alpha")
+            ],
+            [
+                ".example.v1alpha.MapMessage",
+                ".example.v1alpha.FooMetadata",
+                ".example.v1alpha.FooResponse",
+                ".example.v1alpha.FooRequest",
+                ".example.v1alpha.FooRequest.NestedMessage",
+            ],
+        )
+        self.assertEqual(
+            [
+                message_name
+                for message_name in self._FILE_SET.global_messages_map.keys()
+                if message_name.startswith(".google.api")
+            ],
+            [
+                ".google.api.ResourceReference",
+                ".google.api.ResourceDescriptor",
+                ".google.api.CustomHttpPattern",
+                ".google.api.HttpRule",
+                ".google.api.Http",
+            ],
+        )
+        self.assertEqual(
+            [
+                enum_name
+                for enum_name in self._FILE_SET.global_enums_map.keys()
+                if enum_name.startswith(".example.v1alpha")
+            ],
+            [
+                ".example.v1alpha.Enum1",
+                ".example.v1alpha.FooRequest.NestedEnum",
+            ],
+        )
 
     def test_service_wrapper(self):
         service = self._FILE_SET.services_map["Example"]

--- a/test/comparator/test_wrappers.py
+++ b/test/comparator/test_wrappers.py
@@ -52,6 +52,9 @@ class WrappersTest(unittest.TestCase):
         self.assertEqual(
             list(self._FILE_SET.services_map.keys()), ["Operations", "Example"]
         )
+        self.assertEqual(self._FILE_SET.root_package, "example.v1alpha")
+        self.assertEqual(len(self._FILE_SET.definition_files), 1)
+        self.assertEqual(self._FILE_SET.definition_files[0].name, "wrappers.proto")
         self.assertEqual(self._FILE_SET.api_version, "v1alpha")
 
     def test_service_wrapper(self):

--- a/test/comparator/wrappers/test_enum.py
+++ b/test/comparator/wrappers/test_enum.py
@@ -27,6 +27,7 @@ class EnumTest(unittest.TestCase):
             enum.source_code_line,
             "No source code line can be identified by path ().",
         )
+        self.assertEqual(enum.full_name, ".example.foo.enum")
 
     def test_enum_value_properties(self):
         enum_type = make_enum(

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -66,10 +66,10 @@ class FileSetTest(unittest.TestCase):
             )
         ]
         file_foo = make_file_pb2(
-            name="foo.proto", package=".example.v1", services=services, enums=enums
+            name="foo.proto", package="example.v1", services=services, enums=enums
         )
         file_bar = make_file_pb2(
-            name="bar.proto", package=".example.v1", messages=messages
+            name="bar.proto", package="example.v1", messages=messages
         )
         file_set = make_file_set(files=[file_bar, file_foo])
         # Default to be empty.
@@ -84,6 +84,12 @@ class FileSetTest(unittest.TestCase):
         self.assertEqual(
             list(file_set.services_map["ThingDoer"].methods.keys()),
             ["DoThing", "Jump", "Yawn"],
+        )
+        self.assertEqual(
+            list(file_set.global_enums_map.keys()), [".example.v1.Irrelevant"]
+        )
+        self.assertEqual(
+            list(file_set.global_messages_map.keys()), [".example.v1.InnerMessage"]
         )
 
     def test_file_set_resources(self):

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -306,7 +306,6 @@ class FileSetTest(unittest.TestCase):
         file_set = make_file_set(files=[file1, file2, dep1, dep2])
         self.assertEqual(file_set.api_version, "v1beta")
 
-
     def test_file_set_root_package(self):
         dep1 = make_file_pb2(name="dep1", package="example.external")
         dep2 = make_file_pb2(name="dep2", package="example.external")
@@ -324,7 +323,9 @@ class FileSetTest(unittest.TestCase):
         # The package name `example.tutorial` does not have any match for a version.
         self.assertFalse(file_set.api_version)
         # The `proto2` and `proto3` are API definition files, others are dependencies.
-        self.assertEqual([f.name for f in file_set.definition_files], ["proto2", "proto3"])
+        self.assertEqual(
+            [f.name for f in file_set.definition_files], ["proto2", "proto3"]
+        )
         # If the files are totally not related, the root_package will be the first file package.
         file_set = make_file_set(files=[dep1, dep2])
         self.assertEqual(file_set.root_package, "example.external")

--- a/test/comparator/wrappers/test_message.py
+++ b/test/comparator/wrappers/test_message.py
@@ -29,6 +29,7 @@ class MessageTest(unittest.TestCase):
             message.source_code_line,
             "No source code line can be identified by path ().",
         )
+        self.assertEqual(message.full_name, ".example.foo.my_message")
 
     def test_api_version(self):
         message = make_message("Foo", api_version="v1")

--- a/test/tools/mock_descriptors.py
+++ b/test/tools/mock_descriptors.py
@@ -58,11 +58,14 @@ def make_enum(
     proto_file_name: str = "foo",
     locations: Sequence[desc.SourceCodeInfo.Location] = [],
     path: Tuple[int] = (),
+    full_name: str = ".example.foo.enum",
 ) -> wrappers.Enum:
     """Mock an Enum object."""
     source_code_locations = {tuple(location.path): location for location in locations}
     enum_pb = make_enum_pb2(name, values)
-    return wrappers.Enum(enum_pb, proto_file_name, source_code_locations, path)
+    return wrappers.Enum(
+        enum_pb, proto_file_name, source_code_locations, path, full_name
+    )
 
 
 def make_field_pb2(
@@ -170,6 +173,7 @@ def make_message(
     options: desc.MessageOptions = None,
     api_version: str = None,
     map_entry: bool = False,
+    full_name: str = ".example.foo.my_message",
     **kwargs,
 ) -> wrappers.Message:
     message_pb = make_message_pb2(
@@ -190,6 +194,7 @@ def make_message(
         path=path,
         resource_database=resource_database,
         api_version=api_version,
+        full_name=full_name,
         **kwargs,
     )
 


### PR DESCRIPTION
1. Add full_name attribute to `Enum` and `Message` class to avoid the duplicate name in different packages and also help easily query for method input/output type message.
2. Create global information map, which includes the nested messages and enums. Because from a field in the definition file, it can also referenced the nested message type as its type. Details in this [AIP](https://developers.google.com/protocol-buffers/docs/proto3#nested)
3. Unit tests
