### PR TITLE
feat: compare used resources in file_set comparator

### DIFF
--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -189,8 +189,8 @@ class FileSetComparator:
             ).compare()
 
     def _compare_resources(self):
-        resources_original = self.fs_original.resources_database
-        resources_update = self.fs_update.resources_database
+        resources_original = self.fs_original.used_resources_database
+        resources_update = self.fs_update.used_resources_database
         resources_types_original = set(resources_original.types.keys())
         resources_types_update = set(resources_update.types.keys())
         # 1. Patterns of file-level resource definitions have changed.

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -136,7 +136,7 @@ class FileSetTest(unittest.TestCase):
             options=message_options,
         )
         file2 = make_file_pb2(
-            name="bar.proto", package=".example.v1", messages=[message]
+            name="bar.proto", package=".example.bar", messages=[message]
         )
         file_set = make_file_set(files=[file1, file2])
         # All resources should be registered in the database.
@@ -149,6 +149,15 @@ class FileSetTest(unittest.TestCase):
         self.assertEqual(
             list(resource_patterns.keys()),
             ["foo/{foo}", "user/{user}", "user/{user}/bar/", "tests/{test}/"],
+        )
+        # Check used resources database.
+        # File1 depends on file2, but they are not in the same package, only file1
+        # is API definition file. So only resources in file1 are in used_resource_database.
+        self.assertEqual(
+            list(file_set.used_resources_database.types.keys()), ["example.v1/Foo"]
+        )
+        self.assertEqual(
+            list(file_set.used_resources_database.patterns.keys()), ["foo/{foo}"]
         )
 
     def test_file_set_source_code_location(self):


### PR DESCRIPTION
Similar to #113 To avoid comparing not directly used resources definition in dependencies, a separate "used_resources_database" is created, so that only those resources directly defined in file options or message options in **only** API definition files are compared in the file_set comparator. The global resource database is used to check the resource reference in field level.