### PR TITLE
chore: use suitable assertions in tests

### DIFF
--- a/test/comparator/test_resource_database.py
+++ b/test/comparator/test_resource_database.py
@@ -92,11 +92,11 @@ class ResourceDatabaseTest(unittest.TestCase):
         parent_resources = self.resource_database.get_parent_resources_by_child_type(
             "child"
         )
-        self.assertTrue(parent_resource in parent_resources)
+        self.assertIn(parent_resource, parent_resources)
         # Reverse query would not have any result.
-        self.assertTrue(
-            child_resource
-            not in self.resource_database.get_parent_resources_by_child_type("parent")
+        self.assertNotIn(
+            child_resource,
+            self.resource_database.get_parent_resources_by_child_type("parent"),
         )
 
 

--- a/test/comparator/wrappers/test_message.py
+++ b/test/comparator/wrappers/test_message.py
@@ -43,7 +43,7 @@ class MessageTest(unittest.TestCase):
         )
         message = make_message("Message", fields=fields)
         field_one = message.fields[1]
-        self.assertTrue(isinstance(field_one, wrappers.Field))
+        self.assertIsInstance(field_one, wrappers.Field)
         self.assertEqual(field_one.name, "field_one")
 
     def test_map_entry_option(self):

--- a/test/comparator/wrappers/test_service.py
+++ b/test/comparator/wrappers/test_service.py
@@ -48,8 +48,8 @@ class ServiceTest(unittest.TestCase):
     def test_service_scopes(self):
         service = make_service(scopes=("https://foo/user/", "https://foo/admin/"))
         oauth_scopes = [scope.value for scope in service.oauth_scopes]
-        self.assertTrue("https://foo/user/" in oauth_scopes)
-        self.assertTrue("https://foo/admin/" in oauth_scopes)
+        self.assertIn("https://foo/user/", oauth_scopes)
+        self.assertIn("https://foo/admin/", oauth_scopes)
 
     def test_service_no_scopes(self):
         service = make_service()

--- a/test/detector/test_loader.py
+++ b/test/detector/test_loader.py
@@ -52,8 +52,8 @@ class LoaderTest(unittest.TestCase):
             ],
         )
         self.assertTrue(loader.get_descriptor_set())
-        self.assertTrue(
-            isinstance(loader.get_descriptor_set(), descriptor_pb2.FileDescriptorSet)
+        self.assertIsInstance(
+            loader.get_descriptor_set(), descriptor_pb2.FileDescriptorSet
         )
 
     def test_loader_descriptor_set(self):
@@ -73,8 +73,8 @@ class LoaderTest(unittest.TestCase):
         )
         self.assertFalse(loader.proto_files)
         self.assertTrue(loader.get_descriptor_set())
-        self.assertTrue(
-            isinstance(loader.get_descriptor_set(), descriptor_pb2.FileDescriptorSet)
+        self.assertIsInstance(
+            loader.get_descriptor_set(), descriptor_pb2.FileDescriptorSet
         )
 
 

--- a/test/tools/mock_resources.py
+++ b/test/tools/mock_resources.py
@@ -63,6 +63,6 @@ def make_resource_descriptor(
     resource_type: str, resource_patterns: [str]
 ) -> resource_pb2.ResourceDescriptor:
     resource_descriptor = resource_pb2.ResourceDescriptor(
-        type=resource_type, pattern=[pattern for pattern in resource_patterns]
+        type=resource_type, pattern=list(resource_patterns)
     )
     return WithLocation(resource_descriptor, None, None)


### PR DESCRIPTION
When copying code to internal google3, the analyzers in presubmit checks recommend to use more suitable assertions in test.