### PR TITLE
feat: make source code location information optional

### DIFF
--- a/src/detector/loader.py
+++ b/src/detector/loader.py
@@ -35,7 +35,7 @@ class Loader:
         proto_defintion_dirs: Sequence[str],
         proto_files: Sequence[str],
         descriptor_set: str,
-        include_source_code: True,
+        include_source_code: bool = True,
     ):
         self.proto_defintion_dirs = proto_defintion_dirs
         self.descriptor_set = descriptor_set

--- a/src/detector/loader.py
+++ b/src/detector/loader.py
@@ -35,10 +35,12 @@ class Loader:
         proto_defintion_dirs: Sequence[str],
         proto_files: Sequence[str],
         descriptor_set: str,
+        include_source_code: True,
     ):
         self.proto_defintion_dirs = proto_defintion_dirs
         self.descriptor_set = descriptor_set
         self.proto_files = proto_files
+        self.include_source_code = include_source_code
 
     def get_descriptor_set(self) -> desc.FileDescriptorSet:
         desc_set = desc.FileDescriptorSet()
@@ -54,7 +56,8 @@ class Loader:
             protoc_command.append(f"--proto_path={directory}")
         protoc_command.append(f"--proto_path={self.PROTOBUF_PROTOS_DIR}")
         protoc_command.append("-o/dev/stdout")
-        protoc_command.append("--include_source_info")
+        if self.include_source_code:
+            protoc_command.append("--include_source_info")
         # Include the imported dependencies.
         protoc_command.append("--include_imports")
         protoc_command.extend(pf for pf in self.proto_files)

--- a/test/comparator/wrappers/test_enum.py
+++ b/test/comparator/wrappers/test_enum.py
@@ -25,7 +25,7 @@ class EnumTest(unittest.TestCase):
         self.assertEqual(enum.path, ())
         self.assertEqual(
             enum.source_code_line,
-            "No source code line can be identified by path ().",
+            -1,
         )
         self.assertEqual(enum.full_name, ".example.foo.enum")
 

--- a/test/comparator/wrappers/test_enum_value.py
+++ b/test/comparator/wrappers/test_enum_value.py
@@ -25,7 +25,7 @@ class EnumValueTest(unittest.TestCase):
         self.assertEqual(enum_value.proto_file_name, "foo")
         self.assertEqual(
             enum_value.source_code_line,
-            "No source code line can be identified by path ().",
+            -1,
         )
         self.assertEqual(enum_value.path, ())
 

--- a/test/comparator/wrappers/test_message.py
+++ b/test/comparator/wrappers/test_message.py
@@ -27,7 +27,7 @@ class MessageTest(unittest.TestCase):
         self.assertEqual(message.path, ())
         self.assertEqual(
             message.source_code_line,
-            "No source code line can be identified by path ().",
+            -1,
         )
         self.assertEqual(message.full_name, ".example.v1.my_message")
 

--- a/test/comparator/wrappers/test_method.py
+++ b/test/comparator/wrappers/test_method.py
@@ -23,7 +23,7 @@ class MethodTest(unittest.TestCase):
         self.assertEqual(method.path, ())
         self.assertEqual(
             method.source_code_line,
-            "No source code line can be identified by path ().",
+            -1,
         )
 
     def test_method_types(self):

--- a/test/comparator/wrappers/test_service.py
+++ b/test/comparator/wrappers/test_service.py
@@ -30,7 +30,7 @@ class ServiceTest(unittest.TestCase):
         self.assertFalse(service.api_version)
         self.assertEqual(
             service.source_code_line,
-            "No source code line can be identified by path ().",
+            -1,
         )
 
     def test_service_api_version(self):


### PR DESCRIPTION
For internal BCD tool, the mapping of the source code location information will be lost. So add one option in the loader to allow exclude source code information.