### PR TITLE
fix: remove unused import messages

### DIFF
--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -144,6 +144,12 @@ class FileSetComparator:
                 compared_update_keys.add(transformed_name)
             else:
                 # Message only exits in the original version.
+                message = self.fs_original.messages_map[name]
+                definition_files = [f.name for f in self.fs_original.definition_files]
+                if message.proto_file_name not in definition_files:
+                    # The removed message is imported from dependency files.
+                    # This should be caught at the fields level where this message is referenced.
+                    continue
                 DescriptorComparator(
                     self.fs_original.messages_map[name],
                     None,
@@ -151,6 +157,12 @@ class FileSetComparator:
                 ).compare()
         for name in keys_update - compared_update_keys:
             # Message only exits in the update version.
+            message = self.fs_update.messages_map[name]
+            definition_files = [f.name for f in self.fs_update.definition_files]
+            if message.proto_file_name not in definition_files:
+                # The added message is imported from dependency files.
+                # This should be caught at the fields level where this message is referenced.
+                continue
             DescriptorComparator(
                 None,
                 self.fs_update.messages_map[name],
@@ -175,6 +187,12 @@ class FileSetComparator:
                 compared_update_keys.add(transformed_name)
             else:
                 # Enum only exits in the original version.
+                removed_enum = self.fs_original.enums_map[name]
+                definition_files = [f.name for f in self.fs_original.definition_files]
+                if removed_enum.proto_file_name not in definition_files:
+                    # The removed enum is imported from dependency files.
+                    # This should be caught at the fields level where this enum is referenced.
+                    continue
                 EnumComparator(
                     self.fs_original.enums_map[name],
                     None,
@@ -182,6 +200,12 @@ class FileSetComparator:
                 ).compare()
         for name in keys_update - compared_update_keys:
             # Enum only exits in the update version.
+            added_enum = self.fs_update.enums_map[name]
+            definition_files = [f.name for f in self.fs_update.definition_files]
+            if added_enum.proto_file_name not in definition_files:
+                # The added enum is imported from dependency files.
+                # This should be caught at the fields level where this enum is referenced.
+                continue
             EnumComparator(
                 None,
                 self.fs_update.enums_map[name],

--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -30,6 +30,10 @@ class FileSetComparator:
         self.fs_original = file_set_original
         self.fs_update = file_set_update
         self.finding_container = finding_container
+        self.original_definition_files = [
+            f.name for f in self.fs_original.definition_files
+        ]
+        self.update_definition_files = [f.name for f in self.fs_update.definition_files]
 
     def compare(self):
         # 1.Compare the per-language packaging options.
@@ -145,8 +149,7 @@ class FileSetComparator:
             else:
                 # Message only exits in the original version.
                 message = self.fs_original.messages_map[name]
-                definition_files = [f.name for f in self.fs_original.definition_files]
-                if message.proto_file_name not in definition_files:
+                if message.proto_file_name not in self.original_definition_files:
                     # The removed message is imported from dependency files.
                     # This should be caught at the fields level where this message is referenced.
                     continue
@@ -158,8 +161,7 @@ class FileSetComparator:
         for name in keys_update - compared_update_keys:
             # Message only exits in the update version.
             message = self.fs_update.messages_map[name]
-            definition_files = [f.name for f in self.fs_update.definition_files]
-            if message.proto_file_name not in definition_files:
+            if message.proto_file_name not in self.update_definition_files:
                 # The added message is imported from dependency files.
                 # This should be caught at the fields level where this message is referenced.
                 continue
@@ -188,8 +190,7 @@ class FileSetComparator:
             else:
                 # Enum only exits in the original version.
                 removed_enum = self.fs_original.enums_map[name]
-                definition_files = [f.name for f in self.fs_original.definition_files]
-                if removed_enum.proto_file_name not in definition_files:
+                if removed_enum.proto_file_name not in self.original_definition_files:
                     # The removed enum is imported from dependency files.
                     # This should be caught at the fields level where this enum is referenced.
                     continue
@@ -201,8 +202,7 @@ class FileSetComparator:
         for name in keys_update - compared_update_keys:
             # Enum only exits in the update version.
             added_enum = self.fs_update.enums_map[name]
-            definition_files = [f.name for f in self.fs_update.definition_files]
-            if added_enum.proto_file_name not in definition_files:
+            if added_enum.proto_file_name not in self.update_definition_files:
                 # The added enum is imported from dependency files.
                 # This should be caught at the fields level where this enum is referenced.
                 continue


### PR DESCRIPTION
For those dependency files that are no longer imported, we can safely skip the messages checking for them. Since they will be caught at the fields level where the message is referenced.

For example:
```
// original proto file
import google/rpc/code.proto

message test {
   google.rpc.code field1 = 1;
}

// update proto file
message test {
   string field1 = 1;
}
```
The breaking change should be `the type of the field "field1" is changed from "google.rpc.code" to "string"`. So the messages in "google.rpc.code.proto" can skip checking.
