### PR TITLE
feat: return actionable findings list without detector options

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -84,23 +84,23 @@ def detect(
         file_set_original = Loader(
             proto_defintion_dirs=None,
             proto_files=None,
-            descriptor_set=options.original_descriptor_set_file_path,    
+            descriptor_set=options.original_descriptor_set_file_path,
         ).get_descriptor_set()
         file_set_update = Loader(
             proto_defintion_dirs=None,
             proto_files=None,
-            descriptor_set=options.update_descriptor_set_file_path
+            descriptor_set=options.update_descriptor_set_file_path,
         ).get_descriptor_set()
     elif options.use_proto_dirs():
         file_set_original = Loader(
             proto_defintion_dirs=options.original_api_definition_dirs,
             proto_files=options.original_proto_files,
-            descriptor_set=None
+            descriptor_set=None,
         ).get_descriptor_set()
         file_set_update = Loader(
             proto_defintion_dirs=options.update_api_definition_dirs,
             proto_files=options.update_proto_files,
-            descriptor_set=None
+            descriptor_set=None,
         ).get_descriptor_set()
     # 4. Create the detector with two FileDescriptorSet and options.
     # It creates output_json file and prints human-readable message if the option is enabled.

--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -28,7 +28,7 @@ class Detector:
         self,
         descriptor_set_original: desc.FileDescriptorSet,
         descriptor_set_update: desc.FileDescriptorSet,
-        opts: Options,
+        opts: Options = None,
     ):
         self.descriptor_set_original = descriptor_set_original
         self.descriptor_set_update = descriptor_set_update
@@ -42,6 +42,9 @@ class Detector:
             FileSet(self.descriptor_set_update),
             self.finding_container,
         ).compare()
+
+        if not self.opts:
+            return self.finding_container.getActionableFindings()
         # Output json file of findings and human-readable messages if the
         # command line option is enabled.
         with open(self.opts.output_json_path, "w") as write_json_file:

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -19,8 +19,10 @@ from test.tools.mock_descriptors import (
     make_service,
     make_method,
     make_message,
+    make_enum,
 )
 from src.detector.options import Options
+from src.findings.utils import Finding
 
 
 class DectetorTest(unittest.TestCase):
@@ -77,6 +79,22 @@ class DectetorTest(unittest.TestCase):
                 + "my_proto.proto L6: An existing message `input` is removed.\n"
                 + "my_proto.proto L12: An existing message `output` is removed.\n",
             )
+
+    def test_detector_without_opts(self):
+        # Mock original and updated FileDescriptorSet.
+        enum_foo = make_enum(name="foo")
+        enum_bar = make_enum(name="bar")
+        file_set_original = desc.FileDescriptorSet(
+            file=[make_file_pb2(name="original.proto", enums=[enum_foo])]
+        )
+        file_set_update = desc.FileDescriptorSet(
+            file=[make_file_pb2(name="update.proto", enums=[enum_bar])]
+        )
+        breaking_changes = Detector(
+            file_set_original, file_set_update
+        ).detect_breaking_changes()
+        # Without options, the detector returns an array of actionable Findings.
+        self.assertIsInstance(breaking_changes[0], Finding)
 
 
 if __name__ == "__main__":

--- a/test/detector/test_loader.py
+++ b/test/detector/test_loader.py
@@ -21,7 +21,7 @@ from google.protobuf import descriptor_pb2
 class LoaderTest(unittest.TestCase):
     _CURRENT_DIR = os.getcwd()
     COMMON_PROTOS_DIR = os.path.join(os.getcwd(), "api-common-protos")
-    
+
     def test_loader_args(self):
         loader = Loader(
             proto_defintion_dirs=None,
@@ -35,7 +35,6 @@ class LoaderTest(unittest.TestCase):
         self.assertFalse(loader.local_protobuf)
         self.assertEqual(loader.protoc_binary, "//path/to/protoc/binary")
         self.assertEqual(loader.descriptor_set, "//path/to/descriptor/set")
-
 
     def test_loader_proto_dirs(self):
         loader = Loader(


### PR DESCRIPTION
Options in `detector` should be optional, if no opts passed in, then it should return a list of actionable findings (which can be directly read for internal tools).