### PR TITLE
fix: return findings in human-readable message format

### DIFF
--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -44,7 +44,7 @@ class Detector:
         ).compare()
 
         if not self.opts:
-            return self.finding_container.getActionableFindings()
+            return self.finding_container.toHumanReadableMessage()
         # Output json file of findings and human-readable messages if the
         # command line option is enabled.
         with open(self.opts.output_json_path, "w") as write_json_file:

--- a/src/detector/loader.py
+++ b/src/detector/loader.py
@@ -55,7 +55,7 @@ class Loader:
                 desc_set.ParseFromString(f.read())
             return desc_set
         # Construct the protoc command with proper argument prefix.
-        protoc_command = [self.PROTOC_BINARY]
+        protoc_command = [self.protoc_binary]
         for directory in self.proto_definition_dirs:
             protoc_command.append(f"--proto_path={directory}")
         if self.local_protobuf:

--- a/src/findings/finding_container.py
+++ b/src/findings/finding_container.py
@@ -57,7 +57,7 @@ class FindingContainer:
         output_message = ""
         file_to_findings = defaultdict(list)
         for finding in self.getActionableFindings():
-            # Create a map to summarize the findings based on proto file name.s
+            # Create a map to summarize the findings based on proto file name.
             file_to_findings[finding.location.proto_file_name].append(finding)
         # Add each finding to the output message.
         for file_name, findings in file_to_findings.items():
@@ -72,5 +72,8 @@ class FindingContainer:
                 )
             )
             for finding in findings:
-                output_message += f"{file_name} L{finding.location.source_code_line}: {finding.message}\n"
+                if finding.location.source_code_line == -1:
+                    output_message += f"{file_name}: {finding.message}\n"
+                else:
+                    output_message += f"{file_name} L{finding.location.source_code_line}: {finding.message}\n"
         return output_message

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -94,7 +94,7 @@ class DectetorTest(unittest.TestCase):
             file_set_original, file_set_update
         ).detect_breaking_changes()
         # Without options, the detector returns an array of actionable Findings.
-        self.assertIsInstance(breaking_changes[0], Finding)
+        self.assertEqual(breaking_changes, "original.proto: An existing Enum `foo` is removed.\n")
 
 
 if __name__ == "__main__":

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -94,7 +94,9 @@ class DectetorTest(unittest.TestCase):
             file_set_original, file_set_update
         ).detect_breaking_changes()
         # Without options, the detector returns an array of actionable Findings.
-        self.assertEqual(breaking_changes, "original.proto: An existing Enum `foo` is removed.\n")
+        self.assertEqual(
+            breaking_changes, "original.proto: An existing Enum `foo` is removed.\n"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In internal tools, the whole finding will be present as one message, else the tool will only output the changes which are associated with the changed proto file.