### PR TITLE
fix: typo in messages

### DIFF
--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -68,7 +68,7 @@ class FileSetComparator:
                         category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                         proto_file_name=classname_option.proto_file_name,
                         source_code_line=classname_option.source_code_line,
-                        message=f"An exisiting packaging option `{classname}` for `{option}` is removed.",
+                        message=f"An existing packaging option `{classname}` for `{option}` is removed.",
                         change_type=ChangeType.MAJOR,
                     )
             # Compare the option of language namespace. Minor version updates in consideration.
@@ -94,7 +94,7 @@ class FileSetComparator:
                         category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
-                        message=f"An exisiting packaging option `{original_option_value}` for `{option}` is removed.",
+                        message=f"An existing packaging option `{original_option_value}` for `{option}` is removed.",
                         change_type=ChangeType.MAJOR,
                     )
                 for namespace in set(transformed_option_value_update.keys()) - set(

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -154,7 +154,7 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "google/cloud/oslogin/v1/oslogin.proto L34: An exisiting packaging option `Google::Cloud::OsLogin::V1` for `ruby_package` is removed.\n"
+                "google/cloud/oslogin/v1/oslogin.proto L34: An existing packaging option `Google::Cloud::OsLogin::V1` for `ruby_package` is removed.\n"
                 + "google/cloud/oslogin/v1/oslogin.proto L41: An existing default host `oslogin.googleapis.com` is removed.\n"
                 + "google/cloud/oslogin/v1/oslogin.proto L42: An existing oauth_scope `https://www.googleapis.com/auth/cloud-platform` is removed.\n"
                 + "google/cloud/oslogin/v1/oslogin.proto L42: An existing oauth_scope `https://www.googleapis.com/auth/compute` is removed.\n"

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -414,7 +414,7 @@ class FileSetComparatorTest(unittest.TestCase):
         self.assertEqual(finding.category.name, "PACKAGING_OPTION_REMOVAL")
         self.assertEqual(
             finding.message,
-            "An exisiting packaging option `Foo` for `java_outer_classname` is removed.",
+            "An existing packaging option `Foo` for `java_outer_classname` is removed.",
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -448,13 +448,13 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
         java_classname_option_change = findings_map[
-            "An exisiting packaging option `ServiceProto` for `java_outer_classname` is removed."
+            "An existing packaging option `ServiceProto` for `java_outer_classname` is removed."
         ]
         self.assertEqual(
             java_classname_option_change.category.name, "PACKAGING_OPTION_REMOVAL"
         )
         php_namespace_option_removal = findings_map[
-            "An exisiting packaging option `Google\\Cloud\\Service\\V1` for `php_namespace` is removed."
+            "An existing packaging option `Google\\Cloud\\Service\\V1` for `php_namespace` is removed."
         ]
         self.assertEqual(
             php_namespace_option_removal.category.name, "PACKAGING_OPTION_REMOVAL"


### PR DESCRIPTION
Just spotted this typo.

```
$ find . -type f | xargs perl -pi -e 's/xisiting/xisting/g'
```
