### PR TITLE
fix: use protoc binary v3.15.8

### DIFF
--- a/test/testdata/protos/message/v1/message_v1.proto
+++ b/test/testdata/protos/message/v1/message_v1.proto
@@ -5,7 +5,7 @@ package tutorial.v1;
 message Person {
   string name = 1;
   int32 id = 2;
-  string email = 3;
+  optional string email = 3;
 
   enum PhoneType {
     MOBILE = 0;

--- a/test/testdata/protos/message/v1beta1/message_v1beta1.proto
+++ b/test/testdata/protos/message/v1beta1/message_v1beta1.proto
@@ -5,7 +5,7 @@ package tutorial.v1beta1;
 message Person {
   string name = 1;
   string id = 2;
-  string email_address = 3;
+  optional string email_address = 3;
 
   enum PhoneType {
     MOBILE = 0;


### PR DESCRIPTION
The included `protoc` binary has version 3.13.0 which still requires `--experimental_allow_proto3_optional` to allow proto3 optional fields. This option is not needed (since proto3 optional fields are enabled by default) in protoc starting from 3.15.0.

This PR updates `protoc` binary to v3.15.8 (Linux amd64 distribution).

Also, please look at #149 - shipping our own protoc binary is fundamentally wrong :)  We should change this, but for now, let's start from updating it to allow `optional` fields in BCD checks which are currently failing:

```
(venv) root@6dda72dcc508:~# cat test.proto 
syntax = "proto3";

message Opt {
	optional int32 value = 1;
}
(venv) root@6dda72dcc508:~# ../proto-breaking-change-detector/test/tools/protoc --version
libprotoc 3.13.0
(venv) root@6dda72dcc508:~# ../proto-breaking-change-detector/test/tools/protoc -o /dev/stdout test.proto
test.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.
```

With the `protoc` from this PR, it will work.