### PR TITLE
feat: context-aware messages

### DIFF
--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -14,7 +14,7 @@
 
 from src.comparator.enum_value_comparator import EnumValueComparator
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory, ChangeType
+from src.findings.finding_category import FindingCategory, ChangeType
 from src.comparator.wrappers import Enum
 
 
@@ -24,10 +24,12 @@ class EnumComparator:
         enum_original: Enum,
         enum_update: Enum,
         finding_container: FindingContainer,
+        context: str,
     ):
         self.enum_original = enum_original
         self.enum_update = enum_update
         self.finding_container = finding_container
+        self.context = context
 
     def compare(self):
         # 1. If the original EnumDescriptor is None,
@@ -37,7 +39,8 @@ class EnumComparator:
                 category=FindingCategory.ENUM_ADDITION,
                 proto_file_name=self.enum_update.proto_file_name,
                 source_code_line=self.enum_update.source_code_line,
-                message=f"A new Enum `{self.enum_update.name}` is added.",
+                subject=self.enum_update.name,
+                context=self.context,
                 change_type=ChangeType.MINOR,
             )
 
@@ -48,7 +51,8 @@ class EnumComparator:
                 category=FindingCategory.ENUM_REMOVAL,
                 proto_file_name=self.enum_original.proto_file_name,
                 source_code_line=self.enum_original.source_code_line,
-                message=f"An existing Enum `{self.enum_original.name}` is removed.",
+                subject=self.enum_original.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
             )
 
@@ -65,6 +69,7 @@ class EnumComparator:
                     enum_values_dict_original[number],
                     None,
                     self.finding_container,
+                    context=self.enum_update.name,
                 ).compare()
             # Compare Enum values that only exist in the update version.
             for number in enum_values_keys_set_update - enum_values_keys_set_original:
@@ -72,6 +77,7 @@ class EnumComparator:
                     None,
                     enum_values_dict_update[number],
                     self.finding_container,
+                    context=self.enum_update.name,
                 ).compare()
             # Compare Enum values that exist in both original and update versions.
             for number in enum_values_keys_set_original & enum_values_keys_set_update:
@@ -79,4 +85,5 @@ class EnumComparator:
                     enum_values_dict_original[number],
                     enum_values_dict_update[number],
                     self.finding_container,
+                    context=self.enum_update.name,
                 ).compare()

--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory, ChangeType
+from src.findings.finding_category import FindingCategory, ChangeType
 from src.comparator.wrappers import EnumValue
 
 
@@ -23,10 +23,12 @@ class EnumValueComparator:
         enum_value_original: EnumValue,
         enum_value_update: EnumValue,
         finding_container: FindingContainer,
+        context: str,
     ):
         self.enum_value_original = enum_value_original
         self.enum_value_update = enum_value_update
         self.finding_container = finding_container
+        self.context = context
 
     def compare(self):
         # 1. If the original EnumValue is None, then a new EnumValue is added.
@@ -35,7 +37,8 @@ class EnumValueComparator:
                 category=FindingCategory.ENUM_VALUE_ADDITION,
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,
-                message=f"A new EnumValue `{self.enum_value_update.name}` is added.",
+                subject=self.enum_value_update.name,
+                context=self.context,
                 change_type=ChangeType.MINOR,
             )
         # 2. If the updated EnumValue is None, then the original EnumValue is removed.
@@ -44,7 +47,8 @@ class EnumValueComparator:
                 category=FindingCategory.ENUM_VALUE_REMOVAL,
                 proto_file_name=self.enum_value_original.proto_file_name,
                 source_code_line=self.enum_value_original.source_code_line,
-                message=f"An existing EnumValue `{self.enum_value_original.name}` is removed.",
+                subject=self.enum_value_original.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
             )
         # 3. If both EnumValueDescriptors are existing, check if the name is identical.
@@ -53,7 +57,9 @@ class EnumValueComparator:
                 category=FindingCategory.ENUM_VALUE_NAME_CHANGE,
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,
-                message=f"Name of the EnumValue is changed from `{self.enum_value_original.name}` to `{self.enum_value_update.name}`.",
+                subject=self.enum_value_update.name,
+                oldsubject=self.enum_value_original.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
                 extra_info=self.enum_value_update.nested_path,
             )

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory, ChangeType
+from src.findings.finding_category import FindingCategory, ChangeType
 from src.comparator.wrappers import Field
 
 
@@ -28,10 +28,12 @@ class FieldComparator:
         field_original: Field,
         field_update: Field,
         finding_container: FindingContainer,
+        context: str,
     ):
         self.field_original = field_original
         self.field_update = field_update
         self.finding_container = finding_container
+        self.context = context
 
     def compare(self):
         # 1. If original FieldDescriptor is None, then a
@@ -41,7 +43,8 @@ class FieldComparator:
                 category=FindingCategory.FIELD_ADDITION,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.source_code_line,
-                message=f"A new field `{self.field_update.name}` is added.",
+                subject=self.field_update.name,
+                context=self.context,
                 change_type=ChangeType.MINOR,
             )
             return
@@ -53,7 +56,8 @@ class FieldComparator:
                 category=FindingCategory.FIELD_REMOVAL,
                 proto_file_name=self.field_original.proto_file_name,
                 source_code_line=self.field_original.source_code_line,
-                message=f"An existing field `{self.field_original.name}` is removed.",
+                subject=self.field_original.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
             )
             return
@@ -65,7 +69,9 @@ class FieldComparator:
                 category=FindingCategory.FIELD_NAME_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.source_code_line,
-                message=f"Name of an existing field is changed from `{self.field_original.name}` to `{self.field_update.name}`.",
+                oldsubject=self.field_original.name,
+                subject=self.field_update.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
                 extra_info=self.field_update.nested_path,
             )
@@ -78,7 +84,8 @@ class FieldComparator:
                 category=FindingCategory.FIELD_REPEATED_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.repeated.source_code_line,
-                message=f"Repeated state of an existing field `{self.field_original.name}` is changed.",
+                subject=self.field_update.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
                 extra_info=self.field_update.nested_path,
             )
@@ -88,7 +95,8 @@ class FieldComparator:
                 category=FindingCategory.FIELD_BEHAVIOR_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.required.source_code_line,
-                message=f"Field behavior of an existing field `{self.field_original.name}` is changed.",
+                subject=self.field_update.name,
+                context=self.context,
                 change_type=ChangeType.MAJOR,
                 extra_info=self.field_update.nested_path
                 + ["(google.api.field_behavior)"],
@@ -99,7 +107,10 @@ class FieldComparator:
                 category=FindingCategory.FIELD_TYPE_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.proto_type.source_code_line,
-                message=f"Type of an existing field `{self.field_original.name}` is changed from `{self.field_original.proto_type.value}` to `{self.field_update.proto_type.value}`.",
+                subject=self.field_update.name,
+                context=self.context,
+                oldtype=self.field_original.proto_type.value,
+                type=self.field_update.proto_type.value,
                 change_type=ChangeType.MAJOR,
                 extra_info=self.field_update.nested_path,
             )
@@ -122,7 +133,10 @@ class FieldComparator:
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
-                    message=f"Type of an existing field `{self.field_original.name}` is changed from `{self.field_original.type_name.value}` to `{self.field_update.type_name.value}`.",
+                    subject=self.field_original.name,
+                    context=self.context,
+                    oldtype=self.field_original.type_name.value,
+                    type=self.field_update.type_name.value,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
@@ -134,7 +148,10 @@ class FieldComparator:
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
-                    message=f"Type of an existing field `{self.field_original.name}` is changed from a map to `{self.field_update.type_name.value}`.",
+                    subject=self.field_original.name,
+                    context=self.context,
+                    oldtype="map<>",
+                    type=self.field_update.type_name.value,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
@@ -143,7 +160,10 @@ class FieldComparator:
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
-                    message=f"Type of an existing field `{self.field_original.name}` is changed from `{self.field_original.type_name.value}` to a map.",
+                    subject=self.field_original.name,
+                    context=self.context,
+                    oldtype=self.field_original.type_name.value,
+                    type="map<>",
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
@@ -168,7 +188,10 @@ class FieldComparator:
                         category=FindingCategory.FIELD_TYPE_CHANGE,
                         proto_file_name=self.field_update.proto_file_name,
                         source_code_line=self.field_update.type_name.source_code_line,
-                        message=f"Type of an existing field `{self.field_original.name}` is changed from `map<{key_original}, {value_original}>` to `map<{key_update}, {value_update}>`.",
+                        subject=self.field_original.name,
+                        context=self.context,
+                        oldtype=f"map<{key_original}, {value_original}>",
+                        type=f"map<{key_update}, {value_update}>",
                         change_type=ChangeType.MAJOR,
                         extra_info=self.field_update.nested_path,
                     )
@@ -178,22 +201,22 @@ class FieldComparator:
             proto_file_name = self.field_update.proto_file_name
             source_code_line = self.field_update.source_code_line
             if self.field_original.oneof:
-                msg = f"An existing field `{self.field_original.name}` is moved out of One-of."
                 self.finding_container.addFinding(
                     category=FindingCategory.FIELD_ONEOF_MOVE_OUT,
                     proto_file_name=proto_file_name,
                     source_code_line=source_code_line,
-                    message=msg,
+                    subject=self.field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
             else:
-                msg = f"An existing field `{self.field_original.name}` is moved into One-of."
                 self.finding_container.addFinding(
                     category=FindingCategory.FIELD_ONEOF_MOVE_IN,
                     proto_file_name=proto_file_name,
                     source_code_line=source_code_line,
-                    message=msg,
+                    subject=self.field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
@@ -207,7 +230,8 @@ class FieldComparator:
                     category=FindingCategory.FIELD_PROTO3_OPTIONAL_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.source_code_line,
-                    message=f"Proto3 optional state of an existing field `{self.field_original.name}` is changed to required.",
+                    subject=self.field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
@@ -216,7 +240,8 @@ class FieldComparator:
                     category=FindingCategory.FIELD_PROTO3_OPTIONAL_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.source_code_line,
-                    message=f"An existing field `{self.field_original.name}` is changed to proto3 optional.",
+                    subject=self.field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MINOR,
                 )
 
@@ -241,7 +266,8 @@ class FieldComparator:
                     category=FindingCategory.RESOURCE_REFERENCE_ADDITION,
                     proto_file_name=field_update.proto_file_name,
                     source_code_line=resource_ref_update.source_code_line,
-                    message=f"A resource reference option is added to the field `{field_original.name}`, but it is not defined anywhere",
+                    subject=field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MINOR,
                     extra_info=self.field_update.nested_path
                     + ["(google.api.resource_reference)"],
@@ -252,7 +278,8 @@ class FieldComparator:
                     category=FindingCategory.RESOURCE_REFERENCE_ADDITION,
                     proto_file_name=field_update.proto_file_name,
                     source_code_line=resource_ref_update.source_code_line,
-                    message=f"A resource reference option is added to the field `{field_original.name}`.",
+                    subject=field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MINOR,
                 )
             return
@@ -263,15 +290,17 @@ class FieldComparator:
                     category=FindingCategory.RESOURCE_REFERENCE_REMOVAL,
                     proto_file_name=field_original.proto_file_name,
                     source_code_line=resource_ref_original.source_code_line,
-                    message=f"A resource reference option of the field `{field_original.name}` is removed.",
+                    subject=field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MAJOR,
                 )
             else:
                 self.finding_container.addFinding(
-                    category=FindingCategory.RESOURCE_REFERENCE_REMOVAL,
+                    category=FindingCategory.RESOURCE_REFERENCE_MOVED,
                     proto_file_name=field_original.proto_file_name,
                     source_code_line=resource_ref_original.source_code_line,
-                    message=f"A resource reference option of the field `{field_original.name}` is removed, but added back to the message options.",
+                    subject=field_original.name,
+                    context=self.context,
                     change_type=ChangeType.MINOR,
                 )
             return
@@ -290,7 +319,10 @@ class FieldComparator:
                     category=FindingCategory.RESOURCE_REFERENCE_CHANGE,
                     proto_file_name=field_update.proto_file_name,
                     source_code_line=resource_ref_update.source_code_line,
-                    message=f"The type of resource reference option of the field `{field_original.name}` is changed from `{original_type}` to `{update_type}`.",
+                    subject=field_original.name,
+                    context=self.context,
+                    oldtype=original_type,
+                    type=update_type,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path
                     + ["(google.api.resource_reference)", f"{update_type}"],
@@ -379,12 +411,13 @@ class FieldComparator:
         if not any(parent.value.type == parent_type for parent in parent_resources):
             # Resulting referenced resource patterns cannot be resolved identical.
             self.finding_container.addFinding(
-                category=FindingCategory.RESOURCE_REFERENCE_CHANGE,
+                category=FindingCategory.RESOURCE_REFERENCE_CHANGE_CHILD_TYPE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=source_code_line,
-                message=f"The child_type `{child_type}` and type `{parent_type}` of "
-                f"resource reference option in field `{self.field_original.name}` "
-                "cannot be resolved to the identical resource.",
+                subject=self.field_original.name,
+                context=self.context,
+                oldtype=child_type,
+                type=parent_type,
                 change_type=ChangeType.MAJOR,
                 extra_info=self.field_update.nested_path
                 + ["(google.api.resource_reference)"],

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -144,18 +144,22 @@ class FieldComparator:
         # the key type and value type should also be identical.
         elif self.field_original.type_name:
             if self.field_original.is_map_type and not self.field_update.is_map_type:
+                key_original = self.field_original.map_entry_type["key"]
+                value_original = self.field_original.map_entry_type["value"]
                 self.finding_container.addFinding(
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
                     subject=self.field_original.name,
                     context=self.context,
-                    oldtype="map<>",
+                    oldtype=f"map<{key_original}, {value_original}>",
                     type=self.field_update.type_name.value,
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )
             elif not self.field_original.is_map_type and self.field_update.is_map_type:
+                key_update = self.field_update.map_entry_type["key"]
+                value_update = self.field_update.map_entry_type["value"]
                 self.finding_container.addFinding(
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
@@ -163,7 +167,7 @@ class FieldComparator:
                     subject=self.field_original.name,
                     context=self.context,
                     oldtype=self.field_original.type_name.value,
-                    type="map<>",
+                    type=f"map<{key_update}, {value_update}>",
                     change_type=ChangeType.MAJOR,
                     extra_info=self.field_update.nested_path,
                 )

--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -17,7 +17,7 @@ from src.comparator.message_comparator import DescriptorComparator
 from src.comparator.enum_comparator import EnumComparator
 from src.comparator.wrappers import FileSet
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory, ChangeType
+from src.findings.finding_category import FindingCategory, ChangeType
 
 
 class FileSetComparator:
@@ -68,7 +68,8 @@ class FileSetComparator:
                         category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                         proto_file_name=classname_option.proto_file_name,
                         source_code_line=classname_option.source_code_line,
-                        message=f"An existing packaging option `{classname}` for `{option}` is removed.",
+                        type=classname,
+                        subject=option,
                         change_type=ChangeType.MAJOR,
                     )
             # Compare the option of language namespace. Minor version updates in consideration.
@@ -94,7 +95,8 @@ class FileSetComparator:
                         category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
-                        message=f"An existing packaging option `{original_option_value}` for `{option}` is removed.",
+                        type=original_option_value,
+                        subject=option,
                         change_type=ChangeType.MAJOR,
                     )
                 for namespace in set(transformed_option_value_update.keys()) - set(
@@ -108,7 +110,8 @@ class FileSetComparator:
                         category=FindingCategory.PACKAGING_OPTION_ADDITION,
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
-                        message=f"A new packaging option `{original_option_value}` for `{option}` is added.",
+                        type=original_option_value,
+                        subject=option,
                         change_type=ChangeType.MAJOR,
                     )
 
@@ -117,17 +120,24 @@ class FileSetComparator:
         keys_update = set(self.fs_update.services_map.keys())
         for name in keys_original - keys_update:
             ServiceComparator(
-                self.fs_original.services_map[name], None, self.finding_container
+                self.fs_original.services_map[name],
+                None,
+                self.finding_container,
+                context=name,
             ).compare()
         for name in keys_update - keys_original:
             ServiceComparator(
-                None, self.fs_update.services_map[name], self.finding_container
+                None,
+                self.fs_update.services_map[name],
+                self.finding_container,
+                context=name,
             ).compare()
         for name in keys_update & keys_original:
             ServiceComparator(
                 self.fs_original.services_map[name],
                 self.fs_update.services_map[name],
                 self.finding_container,
+                context=name,
             ).compare()
 
     def _compare_messages(self):
@@ -144,6 +154,7 @@ class FileSetComparator:
                     self.fs_original.messages_map[name],
                     self.fs_update.messages_map[transformed_name],
                     self.finding_container,
+                    context=name,
                 ).compare()
                 compared_update_keys.add(transformed_name)
             else:
@@ -157,6 +168,7 @@ class FileSetComparator:
                     self.fs_original.messages_map[name],
                     None,
                     self.finding_container,
+                    context=name,
                 ).compare()
         for name in keys_update - compared_update_keys:
             # Message only exits in the update version.
@@ -169,6 +181,7 @@ class FileSetComparator:
                 None,
                 self.fs_update.messages_map[name],
                 self.finding_container,
+                context=name,
             ).compare()
 
     def _compare_enums(self):
@@ -185,6 +198,7 @@ class FileSetComparator:
                     self.fs_original.enums_map[name],
                     self.fs_update.enums_map[transformed_name],
                     self.finding_container,
+                    context=name,
                 ).compare()
                 compared_update_keys.add(transformed_name)
             else:
@@ -198,6 +212,7 @@ class FileSetComparator:
                     self.fs_original.enums_map[name],
                     None,
                     self.finding_container,
+                    context=name,
                 ).compare()
         for name in keys_update - compared_update_keys:
             # Enum only exits in the update version.
@@ -210,6 +225,7 @@ class FileSetComparator:
                 None,
                 self.fs_update.enums_map[name],
                 self.finding_container,
+                context=name,
             ).compare()
 
     def _compare_resources(self):
@@ -221,35 +237,34 @@ class FileSetComparator:
         for resource_type in resources_types_original & resources_types_update:
             patterns_original = resources_original.types[resource_type].value.pattern
             patterns_update = resources_update.types[resource_type].value.pattern
-            # An existing pattern is removed.
-            if len(patterns_original) > len(patterns_update):
+            # A new pattern is added.
+            for pattern in set(patterns_update) - set(patterns_original):
                 self.finding_container.addFinding(
-                    category=FindingCategory.RESOURCE_PATTERN_REMOVEL,
+                    category=FindingCategory.RESOURCE_PATTERN_ADDITION,
                     proto_file_name=resources_original.types[
                         resource_type
                     ].proto_file_name,
                     source_code_line=resources_original.types[
                         resource_type
                     ].source_code_line,
-                    message=f"An existing pattern value of the resource definition `{resource_type}` is removed.",
+                    type=pattern,
+                    subject=resource_type,
+                    change_type=ChangeType.MINOR,
+                )
+            # An existing pattern is removed.
+            for pattern in set(patterns_original) - set(patterns_update):
+                self.finding_container.addFinding(
+                    category=FindingCategory.RESOURCE_PATTERN_REMOVAL,
+                    proto_file_name=resources_original.types[
+                        resource_type
+                    ].proto_file_name,
+                    source_code_line=resources_original.types[
+                        resource_type
+                    ].source_code_line,
+                    type=pattern,
+                    subject=resource_type,
                     change_type=ChangeType.MAJOR,
                 )
-            # An existing pattern value is changed.
-            # A new pattern value appended to the pattern list is not consider breaking change.
-            for old_pattern, new_pattern in zip(patterns_original, patterns_update):
-                if old_pattern != new_pattern:
-                    self.finding_container.addFinding(
-                        category=FindingCategory.RESOURCE_PATTERN_CHANGE,
-                        proto_file_name=resources_update.types[
-                            resource_type
-                        ].proto_file_name,
-                        source_code_line=resources_update.types[
-                            resource_type
-                        ].source_code_line,
-                        message=f"An existing pattern value of the resource definition `{resource_type}` is updated from `{old_pattern}` to `{new_pattern}`.",
-                        change_type=ChangeType.MAJOR,
-                        extra_info=[f'pattern: "{new_pattern}"'],
-                    )
 
         # 2. File-level resource definitions addition.
         for resource_type in resources_types_update - resources_types_original:
@@ -257,7 +272,7 @@ class FileSetComparator:
                 category=FindingCategory.RESOURCE_DEFINITION_ADDITION,
                 proto_file_name=resources_update.types[resource_type].proto_file_name,
                 source_code_line=resources_update.types[resource_type].source_code_line,
-                message=f"A new resource definition `{resource_type}` has been added.",
+                subject=resource_type,
                 change_type=ChangeType.MINOR,
             )
         # 3. File-level resource definitions removal.
@@ -268,7 +283,7 @@ class FileSetComparator:
                 source_code_line=resources_original.types[
                     resource_type
                 ].source_code_line,
-                message=f"An existing resource definition `{resource_type}` has been removed.",
+                subject=resource_type,
                 change_type=ChangeType.MAJOR,
             )
 

--- a/src/findings/finding.py
+++ b/src/findings/finding.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/findings/finding.py
+++ b/src/findings/finding.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from src.findings.messages import templates
+
+
+class Finding:
+    class _Location:
+        proto_file_name: str
+        source_code_line: int
+
+        def __init__(self, proto_file_name, source_code_line):
+            self.proto_file_name = proto_file_name
+            self.source_code_line = source_code_line
+
+    def __init__(
+        self,
+        category,
+        proto_file_name,
+        source_code_line,
+        change_type,
+        extra_info=None,
+        subject="",
+        oldsubject="",
+        context="",
+        type="",
+        oldtype="",
+    ):
+        self.category = category
+        self.location = self._Location(proto_file_name, source_code_line)
+        self.change_type = change_type
+        self.extra_info = extra_info
+        self.subject = subject
+        self.oldsubject = oldsubject
+        self.context = context
+        self.type = type
+        self.oldtype = oldtype
+
+    def toDict(self):
+        return {
+            "category": self.category.name,
+            "location": {
+                "proto_file_name": self.location.proto_file_name,
+                "source_code_line": self.location.source_code_line,
+            },
+            "change_type": self.change_type.name,
+            "extra_info": self.extra_info,
+            "subject": self.subject,
+            "oldsubject": self.oldsubject,
+            "context": self.context,
+            "type": self.type,
+            "oldtype": self.oldtype,
+        }
+
+    def getMessage(self):
+        format_parameters = self.toDict()
+        return templates[self.category].format(**format_parameters)

--- a/src/findings/finding_category.py
+++ b/src/findings/finding_category.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,15 +36,16 @@ class FindingCategory(enum.Enum):
     RESOURCE_REFERENCE_REMOVAL = 15
     RESOURCE_REFERENCE_ADDITION = 16
     RESOURCE_REFERENCE_CHANGE = 17
+    RESOURCE_REFERENCE_MOVED = 18
+    RESOURCE_REFERENCE_CHANGE_CHILD_TYPE = 19
     # Messages
     MESSAGE_ADDITION = 20
     MESSAGE_REMOVAL = 21
     # Message annotations
     RESOURCE_DEFINITION_ADDITION = 22
-    RESOURCE_DEFINITION_CHANGE = 23
     RESOURCE_DEFINITION_REMOVAL = 24
-    RESOURCE_PATTERN_REMOVEL = 25
-    RESOURCE_PATTERN_CHANGE = 26
+    RESOURCE_PATTERN_REMOVAL = 25
+    RESOURCE_PATTERN_ADDITION = 26
     # Services
     SERVICE_ADDITION = 30
     SERVICE_REMOVAL = 31
@@ -53,8 +54,9 @@ class FindingCategory(enum.Enum):
     SERVICE_HOST_REMOVAL = 33
     SERVICE_HOST_CHANGE = 34
     METHOD_SIGNATURE_REMOVAL = 35
-    METHOD_SIGNATURE_CHANGE = 36
+    METHOD_SIGNATURE_ADDITION = 36
     OAUTH_SCOPE_REMOVAL = 37
+    OAUTH_SCOPE_ADDITION = 38
     # Methods
     METHOD_REMOVAL = 40
     METHOD_ADDTION = 41
@@ -79,40 +81,3 @@ class FindingCategory(enum.Enum):
 class ChangeType(enum.Enum):
     MAJOR = 1
     MINOR = 2
-
-
-class Finding:
-    class _Location:
-        proto_file_name: str
-        source_code_line: int
-
-        def __init__(self, proto_file_name, source_code_line):
-            self.proto_file_name = proto_file_name
-            self.source_code_line = source_code_line
-
-    def __init__(
-        self,
-        category,
-        proto_file_name,
-        source_code_line,
-        message,
-        change_type,
-        extra_info=None,
-    ):
-        self.category = category
-        self.location = self._Location(proto_file_name, source_code_line)
-        self.message = message
-        self.change_type = change_type
-        self.extra_info = extra_info
-
-    def toDict(self):
-        return {
-            "category": self.category.name,
-            "location": {
-                "proto_file_name": self.location.proto_file_name,
-                "source_code_line": self.location.source_code_line,
-            },
-            "message": self.message,
-            "change_type": self.change_type.name,
-            "extra_info": self.extra_info,
-        }

--- a/src/findings/messages.py
+++ b/src/findings/messages.py
@@ -1,0 +1,161 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import defaultdict
+from src.findings.finding_category import FindingCategory
+
+templates = defaultdict(lambda: "Unknown change type")
+templates[
+    FindingCategory.ENUM_VALUE_ADDITION
+] = "A new value `{subject}` is added to enum `{context}`."
+templates[
+    FindingCategory.ENUM_VALUE_REMOVAL
+] = "An existing value `{subject}` is removed from enum `{context}`."
+templates[
+    FindingCategory.ENUM_VALUE_NAME_CHANGE
+] = "Existing value `{oldsubject}` is renamed to `{subject}` in enum `{context}`."
+templates[FindingCategory.ENUM_ADDITION] = "A new enum `{subject}` is added."
+templates[FindingCategory.ENUM_REMOVAL] = "An existing enum `{subject}` is removed."
+templates[
+    FindingCategory.FIELD_ADDITION
+] = "A new field `{subject}` is added to message `{context}`."
+templates[
+    FindingCategory.FIELD_REMOVAL
+] = "An existing field `{subject}` is removed from message `{context}`."
+templates[
+    FindingCategory.FIELD_NAME_CHANGE
+] = "An existing field `{oldsubject}` is renamed to `{subject}` in message `{context}`."
+templates[
+    FindingCategory.FIELD_REPEATED_CHANGE
+] = "Changed repeated flag of an existing field `{subject}` in message `{context}`."
+templates[
+    FindingCategory.FIELD_TYPE_CHANGE
+] = "The type of an existing field `{subject}` is changed from `{oldtype}` to `{type}` in message `{context}`."
+templates[
+    FindingCategory.FIELD_ONEOF_MOVE_OUT
+] = "An existing field `{subject}` is moved out of oneof in message `{context}`."
+templates[
+    FindingCategory.FIELD_ONEOF_MOVE_IN
+] = "An existing field `{subject}` is moved in to oneof in message `{context}`."
+templates[
+    FindingCategory.FIELD_PROTO3_OPTIONAL_CHANGE
+] = "Changed proto3 optional flag of an existing field `{subject}` in message `{context}`."
+templates[
+    FindingCategory.FIELD_BEHAVIOR_CHANGE
+] = "Changed field behavior for an existing field `{subject}` in message `{context}`."
+templates[
+    FindingCategory.RESOURCE_REFERENCE_REMOVAL
+] = "An existing resource_reference option of the field `{subject}` is removed in message `{context}`."
+templates[
+    FindingCategory.RESOURCE_REFERENCE_ADDITION
+] = "A new resource_reference option is added to the field `{subject}` in message `{context}`."
+templates[
+    FindingCategory.RESOURCE_REFERENCE_CHANGE
+] = "A type of an existing resource_reference option of the field `{subject}` in message `{context}` is changed from `{oldtype}` to `{type}`."
+templates[
+    FindingCategory.RESOURCE_REFERENCE_MOVED
+] = "An existing resource_reference option of the field `{subject}` is removed from message `{context}` but moved to another message."
+templates[
+    FindingCategory.RESOURCE_REFERENCE_CHANGE_CHILD_TYPE
+] = "The child_type `{oldtype}` and type `{type}` of resource_reference option in field `{subject}` of message `{context}` cannot be resolved to the identical resource."
+templates[FindingCategory.MESSAGE_ADDITION] = "A new message `{subject}` is added."
+templates[
+    FindingCategory.MESSAGE_REMOVAL
+] = "An existing message `{subject}` is removed."
+templates[
+    FindingCategory.RESOURCE_DEFINITION_ADDITION
+] = "A new resource_definition `{subject}` is added."
+templates[
+    FindingCategory.RESOURCE_DEFINITION_REMOVAL
+] = "An existing resource_definition `{subject}` is removed."
+templates[
+    FindingCategory.RESOURCE_PATTERN_REMOVAL
+] = "An existing resource pattern value `{type}` from the resource definition `{subject}` is removed."
+templates[
+    FindingCategory.RESOURCE_PATTERN_ADDITION
+] = "A new resource pattern value `{type}` added to the resource definition `{subject}`."
+templates[FindingCategory.SERVICE_ADDITION] = "A new service `{subject}` is added."
+templates[
+    FindingCategory.SERVICE_REMOVAL
+] = "An existing service `{subject}` is removed."
+templates[
+    FindingCategory.SERVICE_HOST_ADDITION
+] = "A new default host `{subject}` is added to service `{context}`."
+templates[
+    FindingCategory.SERVICE_HOST_REMOVAL
+] = "An existing default host `{subject}` is removed from service `{context}`."
+templates[
+    FindingCategory.SERVICE_HOST_CHANGE
+] = "An existing default host `{oldsubject}` is changed to `{subject}` in service `{context}`."
+templates[
+    FindingCategory.METHOD_SIGNATURE_REMOVAL
+] = "An existing method_signature `{type}` is removed from method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.METHOD_SIGNATURE_ADDITION
+] = "A new method_signature `{type}` is added to method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.OAUTH_SCOPE_REMOVAL
+] = "An existing oauth_scope `{subject}` is removed from service `{context}`."
+templates[
+    FindingCategory.OAUTH_SCOPE_ADDITION
+] = "A new oauth_scope `{subject}` is added to service `{context}`."
+templates[
+    FindingCategory.METHOD_REMOVAL
+] = "An existing method `{subject}` is removed from service `{context}`."
+templates[
+    FindingCategory.METHOD_ADDTION
+] = "A new method `{subject}` is added to service `{context}`."
+templates[
+    FindingCategory.METHOD_INPUT_TYPE_CHANGE
+] = "Input type of method `{subject}` is changed from `{oldtype}` to `{type}` in service `{context}`."
+templates[
+    FindingCategory.METHOD_RESPONSE_TYPE_CHANGE
+] = "Response type of method `{subject}` is changed from `{oldtype}` to `{type}` in service `{context}`."
+templates[
+    FindingCategory.METHOD_CLIENT_STREAMING_CHANGE
+] = "Client streaming flag is changed for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.METHOD_SERVER_STREAMING_CHANGE
+] = "Server streaming flag is changed for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.METHOD_PAGINATED_RESPONSE_CHANGE
+] = "Pagination feature is changed for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.LRO_RESPONSE_CHANGE
+] = "Long running operation response type is changed from `{oldtype}` to `{type}` for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.LRO_METADATA_CHANGE
+] = "Long running operation metadata type is changed from `{oldtype}` to `{type}` for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.LRO_ANNOTATION_ADDITION
+] = "New long running annotation is added for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.LRO_ANNOTATION_REMOVAL
+] = "Existing long running annitation is removed from method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.HTTP_ANNOTATION_CHANGE
+] = "An existing google.api.http annotation `{type}` is changed for method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.HTTP_ANNOTATION_REMOVAL
+] = "An existing google.api.http annotation is removed from method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.HTTP_ANNOTATION_ADDITION
+] = "A new google.api.http annotation is added to method `{subject}` in service `{context}`."
+templates[
+    FindingCategory.PACKAGING_OPTION_REMOVAL
+] = "An existing packaging option `{type}` for `{subject}` is removed."
+templates[
+    FindingCategory.PACKAGING_OPTION_ADDITION
+] = "A new packaging option `{type}` for `{subject}` is added."

--- a/src/findings/messages.py
+++ b/src/findings/messages.py
@@ -14,148 +14,151 @@
 
 
 from collections import defaultdict
+from types import MappingProxyType
 from src.findings.finding_category import FindingCategory
 
-templates = defaultdict(lambda: "Unknown change type")
-templates[
+_templates = defaultdict(lambda: "Unknown change type")
+_templates[
     FindingCategory.ENUM_VALUE_ADDITION
 ] = "A new value `{subject}` is added to enum `{context}`."
-templates[
+_templates[
     FindingCategory.ENUM_VALUE_REMOVAL
 ] = "An existing value `{subject}` is removed from enum `{context}`."
-templates[
+_templates[
     FindingCategory.ENUM_VALUE_NAME_CHANGE
 ] = "Existing value `{oldsubject}` is renamed to `{subject}` in enum `{context}`."
-templates[FindingCategory.ENUM_ADDITION] = "A new enum `{subject}` is added."
-templates[FindingCategory.ENUM_REMOVAL] = "An existing enum `{subject}` is removed."
-templates[
+_templates[FindingCategory.ENUM_ADDITION] = "A new enum `{subject}` is added."
+_templates[FindingCategory.ENUM_REMOVAL] = "An existing enum `{subject}` is removed."
+_templates[
     FindingCategory.FIELD_ADDITION
 ] = "A new field `{subject}` is added to message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_REMOVAL
 ] = "An existing field `{subject}` is removed from message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_NAME_CHANGE
 ] = "An existing field `{oldsubject}` is renamed to `{subject}` in message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_REPEATED_CHANGE
 ] = "Changed repeated flag of an existing field `{subject}` in message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_TYPE_CHANGE
 ] = "The type of an existing field `{subject}` is changed from `{oldtype}` to `{type}` in message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_ONEOF_MOVE_OUT
 ] = "An existing field `{subject}` is moved out of oneof in message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_ONEOF_MOVE_IN
 ] = "An existing field `{subject}` is moved in to oneof in message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_PROTO3_OPTIONAL_CHANGE
 ] = "Changed proto3 optional flag of an existing field `{subject}` in message `{context}`."
-templates[
+_templates[
     FindingCategory.FIELD_BEHAVIOR_CHANGE
 ] = "Changed field behavior for an existing field `{subject}` in message `{context}`."
-templates[
+_templates[
     FindingCategory.RESOURCE_REFERENCE_REMOVAL
 ] = "An existing resource_reference option of the field `{subject}` is removed in message `{context}`."
-templates[
+_templates[
     FindingCategory.RESOURCE_REFERENCE_ADDITION
 ] = "A new resource_reference option is added to the field `{subject}` in message `{context}`."
-templates[
+_templates[
     FindingCategory.RESOURCE_REFERENCE_CHANGE
 ] = "A type of an existing resource_reference option of the field `{subject}` in message `{context}` is changed from `{oldtype}` to `{type}`."
-templates[
+_templates[
     FindingCategory.RESOURCE_REFERENCE_MOVED
 ] = "An existing resource_reference option of the field `{subject}` is removed from message `{context}` but moved to another message."
-templates[
+_templates[
     FindingCategory.RESOURCE_REFERENCE_CHANGE_CHILD_TYPE
 ] = "The child_type `{oldtype}` and type `{type}` of resource_reference option in field `{subject}` of message `{context}` cannot be resolved to the identical resource."
-templates[FindingCategory.MESSAGE_ADDITION] = "A new message `{subject}` is added."
-templates[
+_templates[FindingCategory.MESSAGE_ADDITION] = "A new message `{subject}` is added."
+_templates[
     FindingCategory.MESSAGE_REMOVAL
 ] = "An existing message `{subject}` is removed."
-templates[
+_templates[
     FindingCategory.RESOURCE_DEFINITION_ADDITION
 ] = "A new resource_definition `{subject}` is added."
-templates[
+_templates[
     FindingCategory.RESOURCE_DEFINITION_REMOVAL
 ] = "An existing resource_definition `{subject}` is removed."
-templates[
+_templates[
     FindingCategory.RESOURCE_PATTERN_REMOVAL
 ] = "An existing resource pattern value `{type}` from the resource definition `{subject}` is removed."
-templates[
+_templates[
     FindingCategory.RESOURCE_PATTERN_ADDITION
 ] = "A new resource pattern value `{type}` added to the resource definition `{subject}`."
-templates[FindingCategory.SERVICE_ADDITION] = "A new service `{subject}` is added."
-templates[
+_templates[FindingCategory.SERVICE_ADDITION] = "A new service `{subject}` is added."
+_templates[
     FindingCategory.SERVICE_REMOVAL
 ] = "An existing service `{subject}` is removed."
-templates[
+_templates[
     FindingCategory.SERVICE_HOST_ADDITION
 ] = "A new default host `{subject}` is added to service `{context}`."
-templates[
+_templates[
     FindingCategory.SERVICE_HOST_REMOVAL
 ] = "An existing default host `{subject}` is removed from service `{context}`."
-templates[
+_templates[
     FindingCategory.SERVICE_HOST_CHANGE
 ] = "An existing default host `{oldsubject}` is changed to `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_SIGNATURE_REMOVAL
 ] = "An existing method_signature `{type}` is removed from method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_SIGNATURE_ADDITION
 ] = "A new method_signature `{type}` is added to method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.OAUTH_SCOPE_REMOVAL
 ] = "An existing oauth_scope `{subject}` is removed from service `{context}`."
-templates[
+_templates[
     FindingCategory.OAUTH_SCOPE_ADDITION
 ] = "A new oauth_scope `{subject}` is added to service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_REMOVAL
 ] = "An existing method `{subject}` is removed from service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_ADDTION
 ] = "A new method `{subject}` is added to service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_INPUT_TYPE_CHANGE
 ] = "Input type of method `{subject}` is changed from `{oldtype}` to `{type}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_RESPONSE_TYPE_CHANGE
 ] = "Response type of method `{subject}` is changed from `{oldtype}` to `{type}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_CLIENT_STREAMING_CHANGE
 ] = "Client streaming flag is changed for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_SERVER_STREAMING_CHANGE
 ] = "Server streaming flag is changed for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.METHOD_PAGINATED_RESPONSE_CHANGE
 ] = "Pagination feature is changed for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.LRO_RESPONSE_CHANGE
 ] = "Long running operation response type is changed from `{oldtype}` to `{type}` for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.LRO_METADATA_CHANGE
 ] = "Long running operation metadata type is changed from `{oldtype}` to `{type}` for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.LRO_ANNOTATION_ADDITION
 ] = "New long running annotation is added for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.LRO_ANNOTATION_REMOVAL
 ] = "Existing long running annitation is removed from method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.HTTP_ANNOTATION_CHANGE
 ] = "An existing google.api.http annotation `{type}` is changed for method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.HTTP_ANNOTATION_REMOVAL
 ] = "An existing google.api.http annotation is removed from method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.HTTP_ANNOTATION_ADDITION
 ] = "A new google.api.http annotation is added to method `{subject}` in service `{context}`."
-templates[
+_templates[
     FindingCategory.PACKAGING_OPTION_REMOVAL
 ] = "An existing packaging option `{type}` for `{subject}` is removed."
-templates[
+_templates[
     FindingCategory.PACKAGING_OPTION_ADDITION
 ] = "A new packaging option `{type}` for `{subject}` is added."
+
+templates = MappingProxyType(_templates)

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -41,7 +41,7 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "enum_v1.proto L5: An existing Enum `BookType` is removed.\n",
+                "enum_v1.proto L5: An existing enum `BookType` is removed.\n",
             )
 
     def test_single_directory_enum(self):
@@ -62,7 +62,7 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "enum_v1.proto L5: An existing Enum `BookType` is removed.\n",
+                "enum_v1.proto L5: An existing enum `BookType` is removed.\n",
             )
 
     def test_single_directory_enum_json(self):
@@ -104,11 +104,11 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "message_v1beta1.proto L7: Type of an existing field `id` is changed from `int32` to `string`.\n"
-                + "message_v1beta1.proto L8: Name of an existing field is changed from `email` to `email_address`.\n"
-                + "message_v1beta1.proto L21: Repeated state of an existing field `phones` is changed.\n"
-                + "message_v1beta1.proto L22: An existing field `single` is moved out of One-of.\n"
-                + "message_v1.proto L18: An existing field `type` is removed.\n",
+                "message_v1.proto L18: An existing field `type` is removed from message `.tutorial.v1.Person`.\n"
+                + "message_v1beta1.proto L7: The type of an existing field `id` is changed from `int32` to `string` in message `.tutorial.v1.Person`.\n"
+                + "message_v1beta1.proto L8: An existing field `email` is renamed to `email_address` in message `.tutorial.v1.Person`.\n"
+                + "message_v1beta1.proto L21: Changed repeated flag of an existing field `phones` in message `.tutorial.v1.Person`.\n"
+                + "message_v1beta1.proto L22: An existing field `single` is moved out of oneof in message `.tutorial.v1.Person`.\n",
             )
 
     def test_single_directory_service(self):
@@ -127,16 +127,16 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "service_v1.proto L11: An existing rpc method `shouldRemove` is removed.\n"
-                + "service_v1.proto L21: An existing field `page_size` is removed.\n"
-                + "service_v1.proto L22: An existing field `page_token` is removed.\n"
-                + "service_v1.proto L26: An existing field `content` is removed.\n"
-                + "service_v1.proto L27: An existing field `next_page_token` is removed.\n"
-                + "service_v1beta1.proto L7: Input type of an existing method `Foo` is changed from `.example.v1.FooRequest` to `.example.v1beta1.FooRequestUpdate`.\n"
-                + "service_v1beta1.proto L7: Output type of an existing method `Foo` is changed from `.example.v1.FooResponse` to `.example.v1beta1.FooResponseUpdate`.\n"
-                + "service_v1beta1.proto L9: The request streaming type of an existing method `Bar` is changed.\n"
-                + "service_v1beta1.proto L9: The response streaming type of an existing method `Bar` is changed.\n"
-                + "service_v1beta1.proto L11: The paginated response of an existing method `paginatedMethod` is changed.\n",
+                "service_v1.proto L11: An existing method `shouldRemove` is removed from service `Example`.\n"
+                + "service_v1.proto L21: An existing field `page_size` is removed from message `.example.v1.BarRequest`.\n"
+                + "service_v1.proto L22: An existing field `page_token` is removed from message `.example.v1.BarRequest`.\n"
+                + "service_v1.proto L26: An existing field `content` is removed from message `.example.v1.BarResponse`.\n"
+                + "service_v1.proto L27: An existing field `next_page_token` is removed from message `.example.v1.BarResponse`.\n"
+                + "service_v1beta1.proto L7: Input type of method `Foo` is changed from `.example.v1.FooRequest` to `.example.v1beta1.FooRequestUpdate` in service `Example`.\n"
+                + "service_v1beta1.proto L7: Response type of method `Foo` is changed from `.example.v1.FooResponse` to `.example.v1beta1.FooResponseUpdate` in service `Example`.\n"
+                + "service_v1beta1.proto L9: Client streaming flag is changed for method `Bar` in service `Example`.\n"
+                + "service_v1beta1.proto L9: Server streaming flag is changed for method `Bar` in service `Example`.\n"
+                + "service_v1beta1.proto L11: Pagination feature is changed for method `paginatedMethod` in service `Example`.\n",
             )
 
     def test_single_directory_service_annotation(self):
@@ -155,12 +155,10 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "service_annotation_v1beta1.proto L14: An existing http method of google.api.http annotation is changed for method `Foo`.\n"
-                + "service_annotation_v1beta1.proto L18: An existing method_signature for method `Foo` is changed from `content` to `error`.\n"
-                + "service_annotation_v1beta1.proto L18: An existing method_signature for method `Foo` is changed from `error` to `content`.\n"
-                + "service_annotation_v1beta1.proto L22: An existing http method body of google.api.http annotation is changed for method `Bar`.\n"
-                + "service_annotation_v1beta1.proto L26: The metadata_type of an existing LRO operation_info annotation for method `Bar` is changed from `FooMetadata` to `FooMetadataUpdate`.\n"
-                + "service_annotation_v1.proto L40: An existing message `FooMetadata` is removed.\n",
+                "service_annotation_v1.proto L40: An existing message `FooMetadata` is removed.\n"
+                + "service_annotation_v1beta1.proto L14: An existing google.api.http annotation `http_method` is changed for method `Foo` in service `Example`.\n"
+                + "service_annotation_v1beta1.proto L22: An existing google.api.http annotation `http_body` is changed for method `Bar` in service `Example`.\n"
+                + "service_annotation_v1beta1.proto L26: Long running operation metadata type is changed from `FooMetadata` to `FooMetadataUpdate` for method `Bar` in service `Example`.\n",
             )
 
     def test_oslogin_proto_alpha(self):
@@ -180,23 +178,27 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(
                 result.output,
                 "google/cloud/oslogin/v1/oslogin.proto L34: An existing packaging option `Google::Cloud::OsLogin::V1` for `ruby_package` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L41: An existing default host `oslogin.googleapis.com` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L42: An existing oauth_scope `https://www.googleapis.com/auth/cloud-platform` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L42: An existing oauth_scope `https://www.googleapis.com/auth/compute` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L51: An existing method_signature is removed from method `DeletePosixAccount`.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L59: An existing method_signature is removed from method `DeleteSshPublicKey`.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L68: An existing method_signature is removed from method `GetLoginProfile`.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L76: An existing method_signature is removed from method `GetSshPublicKey`.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L87: An existing method_signature is removed from method `ImportSshPublicKey`.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L98: An existing method_signature is removed from method `UpdateSshPublicKey`.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L123: A resource reference option of the field `name` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L136: A resource reference option of the field `name` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L147: A resource reference option of the field `name` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L153: An existing field `project_id` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L156: An existing field `system_id` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L166: A resource reference option of the field `name` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L177: A resource reference option of the field `parent` is removed.\n"
-                + "google/cloud/oslogin/v1/oslogin.proto L202: A resource reference option of the field `name` is removed.\n",
+                + "google/cloud/oslogin/v1/oslogin.proto L41: An existing default host `oslogin.googleapis.com` is removed from service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L42: An existing oauth_scope `https://www.googleapis.com/auth/cloud-platform` is removed from service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L42: An existing oauth_scope `https://www.googleapis.com/auth/compute` is removed from service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L51: An existing method_signature `name` is removed from method `DeletePosixAccount` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L59: An existing method_signature `name` is removed from method `DeleteSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L68: An existing method_signature `name` is removed from method `GetLoginProfile` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L76: An existing method_signature `name` is removed from method `GetSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L87: An existing method_signature `parent` is removed from method `ImportSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L87: An existing method_signature `project_id` is removed from method `ImportSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L87: An existing method_signature `ssh_public_key` is removed from method `ImportSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L98: An existing method_signature `name` is removed from method `UpdateSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L98: An existing method_signature `ssh_public_key` is removed from method `UpdateSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L98: An existing method_signature `update_mask` is removed from method `UpdateSshPublicKey` in service `OsLoginService`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L123: An existing resource_reference option of the field `name` is removed in message `.google.cloud.oslogin.v1.DeletePosixAccountRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L136: An existing resource_reference option of the field `name` is removed in message `.google.cloud.oslogin.v1.DeleteSshPublicKeyRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L147: An existing resource_reference option of the field `name` is removed in message `.google.cloud.oslogin.v1.GetLoginProfileRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L153: An existing field `project_id` is removed from message `.google.cloud.oslogin.v1.GetLoginProfileRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L156: An existing field `system_id` is removed from message `.google.cloud.oslogin.v1.GetLoginProfileRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L166: An existing resource_reference option of the field `name` is removed in message `.google.cloud.oslogin.v1.GetSshPublicKeyRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L177: An existing resource_reference option of the field `parent` is removed in message `.google.cloud.oslogin.v1.ImportSshPublicKeyRequest`.\n"
+                + "google/cloud/oslogin/v1/oslogin.proto L202: An existing resource_reference option of the field `name` is removed in message `.google.cloud.oslogin.v1.UpdateSshPublicKeyRequest`.\n",
             )
 
     def test_oslogin_proto_beta(self):
@@ -215,7 +217,7 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "google/cloud/oslogin/v1beta/oslogin.proto L179: Field behavior of an existing field `ssh_public_key` is changed.\n",
+                "google/cloud/oslogin/v1beta/oslogin.proto L179: Changed field behavior for an existing field `ssh_public_key` in message `.google.cloud.oslogin.v1.ImportSshPublicKeyRequest`.\n",
             )
 
     def test_pubsub_proto(self):
@@ -238,27 +240,27 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "google/pubsub/v1/pubsub.proto L160: Field behavior of an existing field `name` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L221: Field behavior of an existing field `topic` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L245: Field behavior of an existing field `topic` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L250: Field behavior of an existing field `messages` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L266: Field behavior of an existing field `project` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L296: Field behavior of an existing field `topic` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L356: Field behavior of an existing field `topic` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L617: Field behavior of an existing field `name` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L623: Field behavior of an existing field `topic` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L880: Field behavior of an existing field `subscription` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L903: Field behavior of an existing field `project` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L934: Field behavior of an existing field `subscription` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L946: Field behavior of an existing field `subscription` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L958: Field behavior of an existing field `push_config` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L966: Field behavior of an existing field `subscription` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L985: Field behavior of an existing field `max_messages` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L1002: Field behavior of an existing field `subscription` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L1019: Field behavior of an existing field `ack_deadline_seconds` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L1027: Field behavior of an existing field `subscription` is changed.\n"
-                + "google/pubsub/v1/pubsub.proto L1036: Field behavior of an existing field `ack_ids` is changed.\n"
-                + "google/pubsub/v1beta2/pubsub.proto L369: An existing field `ack_id` is removed.\n",
+                "google/pubsub/v1/pubsub.proto L160: Changed field behavior for an existing field `name` in message `.google.pubsub.v1beta2.Topic`.\n"
+                + "google/pubsub/v1/pubsub.proto L221: Changed field behavior for an existing field `topic` in message `.google.pubsub.v1beta2.GetTopicRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L245: Changed field behavior for an existing field `topic` in message `.google.pubsub.v1beta2.PublishRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L250: Changed field behavior for an existing field `messages` in message `.google.pubsub.v1beta2.PublishRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L266: Changed field behavior for an existing field `project` in message `.google.pubsub.v1beta2.ListTopicsRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L296: Changed field behavior for an existing field `topic` in message `.google.pubsub.v1beta2.ListTopicSubscriptionsRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L356: Changed field behavior for an existing field `topic` in message `.google.pubsub.v1beta2.DeleteTopicRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L617: Changed field behavior for an existing field `name` in message `.google.pubsub.v1beta2.Subscription`.\n"
+                + "google/pubsub/v1/pubsub.proto L623: Changed field behavior for an existing field `topic` in message `.google.pubsub.v1beta2.Subscription`.\n"
+                + "google/pubsub/v1/pubsub.proto L880: Changed field behavior for an existing field `subscription` in message `.google.pubsub.v1beta2.GetSubscriptionRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L903: Changed field behavior for an existing field `project` in message `.google.pubsub.v1beta2.ListSubscriptionsRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L934: Changed field behavior for an existing field `subscription` in message `.google.pubsub.v1beta2.DeleteSubscriptionRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L946: Changed field behavior for an existing field `subscription` in message `.google.pubsub.v1beta2.ModifyPushConfigRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L958: Changed field behavior for an existing field `push_config` in message `.google.pubsub.v1beta2.ModifyPushConfigRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L966: Changed field behavior for an existing field `subscription` in message `.google.pubsub.v1beta2.PullRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L985: Changed field behavior for an existing field `max_messages` in message `.google.pubsub.v1beta2.PullRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L1002: Changed field behavior for an existing field `subscription` in message `.google.pubsub.v1beta2.ModifyAckDeadlineRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L1019: Changed field behavior for an existing field `ack_deadline_seconds` in message `.google.pubsub.v1beta2.ModifyAckDeadlineRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L1027: Changed field behavior for an existing field `subscription` in message `.google.pubsub.v1beta2.AcknowledgeRequest`.\n"
+                + "google/pubsub/v1/pubsub.proto L1036: Changed field behavior for an existing field `ack_ids` in message `.google.pubsub.v1beta2.AcknowledgeRequest`.\n"
+                + "google/pubsub/v1beta2/pubsub.proto L369: An existing field `ack_id` is removed from message `.google.pubsub.v1beta2.ModifyAckDeadlineRequest`.\n",
             )
 
     def test_tts_proto(self):
@@ -277,12 +279,12 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "google/cloud/texttospeech/v1beta1/cloud_tts.proto L103: An existing EnumValue `MP3_64_KBPS` is removed.\n"
-                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L113: An existing EnumValue `MULAW` is removed.\n"
-                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L142: An existing Enum `TimepointType` is removed.\n"
-                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L160: An existing field `enable_time_pointing` is removed.\n"
-                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L275: An existing field `timepoints` is removed.\n"
-                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L278: An existing field `audio_config` is removed.\n"
+                "google/cloud/texttospeech/v1beta1/cloud_tts.proto L103: An existing value `MP3_64_KBPS` is removed from enum `AudioEncoding`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L113: An existing value `MULAW` is removed from enum `AudioEncoding`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L142: An existing enum `TimepointType` is removed.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L160: An existing field `enable_time_pointing` is removed from message `.google.cloud.texttospeech.v1beta1.SynthesizeSpeechRequest`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L275: An existing field `timepoints` is removed from message `.google.cloud.texttospeech.v1beta1.SynthesizeSpeechResponse`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L278: An existing field `audio_config` is removed from message `.google.cloud.texttospeech.v1beta1.SynthesizeSpeechResponse`.\n"
                 + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L283: An existing message `Timepoint` is removed.\n",
             )
 

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -51,34 +51,39 @@ class EnumComparatorTest(unittest.TestCase):
         # fmt: on
 
     def test_enum_removal(self):
-        EnumComparator(self.enum_foo, None, self.finding_container).compare()
+        EnumComparator(
+            self.enum_foo, None, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "An existing Enum `Foo` is removed.")
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_enum_addition(self):
-        EnumComparator(None, self.enum_bar, self.finding_container).compare()
+        EnumComparator(
+            None, self.enum_bar, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "A new Enum `Bar` is added.")
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_enum_value_change(self):
-        EnumComparator(self.enum_foo, self.enum_bar, self.finding_container).compare()
+        EnumComparator(
+            self.enum_foo, self.enum_bar, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "A new EnumValue `VALUE2` is added.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
         self.assertEqual(finding.location.source_code_line, 3)
 
     def test_no_api_change(self):
-        EnumComparator(self.enum_foo, self.enum_foo, self.finding_container).compare()
+        EnumComparator(
+            self.enum_foo, self.enum_foo, self.finding_container, context="ctx"
+        ).compare()
         self.assertEqual(len(self.finding_container.getAllFindings()), 0)
 
 

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -44,18 +44,19 @@ class EnumValueComparatorTest(unittest.TestCase):
             self.enum_foo,
             None,
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "An existing EnumValue `FOO` is removed.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
         self.assertEqual(finding.location.source_code_line, 2)
 
     def test_enum_value_addition(self):
-        EnumValueComparator(None, self.enum_foo, self.finding_container).compare()
+        EnumValueComparator(
+            None, self.enum_foo, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "A new EnumValue `FOO` is added.")
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
@@ -63,12 +64,9 @@ class EnumValueComparatorTest(unittest.TestCase):
 
     def test_name_change(self):
         EnumValueComparator(
-            self.enum_foo, self.enum_bar, self.finding_container
+            self.enum_foo, self.enum_bar, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message, "Name of the EnumValue is changed from `FOO` to `BAR`."
-        )
         self.assertEqual(finding.category.name, "ENUM_VALUE_NAME_CHANGE")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
@@ -76,7 +74,7 @@ class EnumValueComparatorTest(unittest.TestCase):
 
     def test_no_api_change(self):
         EnumValueComparator(
-            self.enum_foo, self.enum_foo, self.finding_container
+            self.enum_foo, self.enum_foo, self.finding_container, context="ctx"
         ).compare()
         self.assertEqual(len(self.finding_container.getAllFindings()), 0)
 

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -32,41 +32,37 @@ class FieldComparatorTest(unittest.TestCase):
 
     def test_field_removal(self):
         field_foo = make_field("Foo")
-        FieldComparator(field_foo, None, self.finding_container).compare()
+        FieldComparator(
+            field_foo, None, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "An existing field `Foo` is removed.")
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
     def test_field_addition(self):
         field_foo = make_field("Foo")
-        FieldComparator(None, field_foo, self.finding_container).compare()
+        FieldComparator(
+            None, field_foo, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "A new field `Foo` is added.")
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
 
     def test_name_change(self):
         field_foo = make_field("Foo")
         field_bar = make_field("Bar")
-        FieldComparator(field_foo, field_bar, self.finding_container).compare()
+        FieldComparator(
+            field_foo, field_bar, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Name of an existing field is changed from `Foo` to `Bar`.",
-        )
         self.assertEqual(finding.category.name, "FIELD_NAME_CHANGE")
 
     def test_repeated_label_change(self):
         field_repeated = make_field(repeated=True)
         field_non_repeated = make_field(repeated=False)
         FieldComparator(
-            field_repeated, field_non_repeated, self.finding_container
+            field_repeated, field_non_repeated, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Repeated state of an existing field `my_field` is changed.",
-        )
         self.assertEqual(finding.category.name, "FIELD_REPEATED_CHANGE")
 
     def test_field_behavior_change(self):
@@ -74,43 +70,33 @@ class FieldComparatorTest(unittest.TestCase):
         field_non_required = make_field(required=False)
         # Required to optional, non-breaking change.
         FieldComparator(
-            field_required, field_non_required, self.finding_container
+            field_required, field_non_required, self.finding_container, context="ctx"
         ).compare()
         findings = self.finding_container.getAllFindings()
         self.assertFalse(findings)
         # Required to optional, non-breaking change.
         FieldComparator(
-            field_non_required, field_required, self.finding_container
+            field_non_required, field_required, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Field behavior of an existing field `my_field` is changed.",
-        )
         self.assertEqual(finding.category.name, "FIELD_BEHAVIOR_CHANGE")
 
     def test_primitive_type_change(self):
         field_int = make_field(proto_type="TYPE_INT32")
         field_string = make_field(proto_type="TYPE_STRING")
-        FieldComparator(field_int, field_string, self.finding_container).compare()
+        FieldComparator(
+            field_int, field_string, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Type of an existing field `my_field` is changed from `int32` to `string`.",
-        )
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
 
     def test_message_type_change(self):
         field_message = make_field(type_name=".example.v1.Enum")
         field_message_update = make_field(type_name=".example.v1beta1.EnumUpdate")
         FieldComparator(
-            field_message, field_message_update, self.finding_container
+            field_message, field_message_update, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Type of an existing field `my_field` is changed from `.example.v1.Enum` to `.example.v1beta1.EnumUpdate`.",
-        )
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
 
     def test_message_type_change_minor_version_update(self):
@@ -119,7 +105,7 @@ class FieldComparatorTest(unittest.TestCase):
             type_name=".example.v1beta1.Enum", api_version="v1beta1"
         )
         FieldComparator(
-            field_message, field_message_update, self.finding_container
+            field_message, field_message_update, self.finding_container, context="ctx"
         ).compare()
         findings = self.finding_container.getAllFindings()
         self.assertFalse(findings)
@@ -141,12 +127,10 @@ class FieldComparatorTest(unittest.TestCase):
             type_name=".exmaple.MapEntry",
             map_entry={"key": key_field, "value": value_field},
         )
-        FieldComparator(field_no_map, field_map, self.finding_container).compare()
+        FieldComparator(
+            field_no_map, field_map, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Type of an existing field `my_field` is changed from `.exmaple.MapEntry` to a map.",
-        )
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -168,12 +152,10 @@ class FieldComparatorTest(unittest.TestCase):
             type_name=".exmaple.MapEntry",
             map_entry={"key": key_field, "value": value_field},
         )
-        FieldComparator(field_map, field_no_map, self.finding_container).compare()
+        FieldComparator(
+            field_map, field_no_map, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Type of an existing field `my_field` is changed from a map to `.exmaple.MapEntry`.",
-        )
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -201,12 +183,10 @@ class FieldComparatorTest(unittest.TestCase):
             map_entry={"key": key_update, "value": value_update},
         )
 
-        FieldComparator(field_original, field_update, self.finding_container).compare()
+        FieldComparator(
+            field_original, field_update, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Type of an existing field `my_field` is changed from `map<string, string>` to `map<.example.key, .example.value>`.",
-        )
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -237,25 +217,37 @@ class FieldComparatorTest(unittest.TestCase):
             api_version="v1beta1",
         )
 
-        FieldComparator(field_original, field_update, self.finding_container).compare()
+        FieldComparator(
+            field_original, field_update, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()
         self.assertFalse(finding)
 
     def test_out_oneof(self):
         field_oneof = make_field(name="Foo", oneof_index=0, oneof_name="oneof_field")
         field_not_oneof = make_field(name="Foo")
-        FieldComparator(field_oneof, field_not_oneof, self.finding_container).compare()
-        findings = {f.message: f for f in self.finding_container.getAllFindings()}
-        finding = findings["An existing field `Foo` is moved out of One-of."]
-        self.assertEqual(finding.category.name, "FIELD_ONEOF_MOVE_OUT")
+        FieldComparator(
+            field_oneof, field_not_oneof, self.finding_container, context="ctx"
+        ).compare()
+        finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "FIELD_ONEOF_MOVE_OUT"
+        )
+        self.assertTrue(finding)
 
     def test_into_oneof(self):
         field_oneof = make_field(name="Foo", oneof_index=0, oneof_name="oneof_field")
         field_not_oneof = make_field(name="Foo")
-        FieldComparator(field_not_oneof, field_oneof, self.finding_container).compare()
-        findings = {f.message: f for f in self.finding_container.getAllFindings()}
-        finding = findings["An existing field `Foo` is moved into One-of."]
-        self.assertEqual(finding.category.name, "FIELD_ONEOF_MOVE_IN")
+        FieldComparator(
+            field_not_oneof, field_oneof, self.finding_container, context="ctx"
+        ).compare()
+        finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "FIELD_ONEOF_MOVE_IN"
+        )
+        self.assertTrue(finding)
 
     def test_proto3_optional_to_required(self):
         # Change an proto3 optional field to required. Breaking change.
@@ -266,13 +258,9 @@ class FieldComparatorTest(unittest.TestCase):
             name="Foo", oneof_index=0, oneof_name="oneof_field"
         )
         FieldComparator(
-            field_optional, field_not_optional, self.finding_container
+            field_optional, field_not_optional, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "Proto3 optional state of an existing field `Foo` is changed to required.",
-        )
         self.assertEqual(finding.category.name, "FIELD_PROTO3_OPTIONAL_CHANGE")
 
     def test_proto3_required_to_optional(self):
@@ -284,13 +272,9 @@ class FieldComparatorTest(unittest.TestCase):
             name="Foo", oneof_index=0, oneof_name="oneof_field"
         )
         FieldComparator(
-            field_not_optional, field_optional, self.finding_container
+            field_not_optional, field_optional, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "An existing field `Foo` is changed to proto3 optional.",
-        )
         self.assertEqual(finding.category.name, "FIELD_PROTO3_OPTIONAL_CHANGE")
 
     def test_resource_reference_addition_breaking(self):
@@ -304,14 +288,13 @@ class FieldComparatorTest(unittest.TestCase):
         )
         field_with_reference = make_field(name="Test", options=field_options)
         FieldComparator(
-            field_without_reference, field_with_reference, self.finding_container
+            field_without_reference,
+            field_with_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_ADDITION")
-        self.assertEqual(
-            finding.message,
-            "A resource reference option is added to the field `Test`, but it is not defined anywhere",
-        )
 
     def test_resource_reference_type_addition_non_breaking(self):
         # The added resource reference is in the database. Non-breaking change.
@@ -331,12 +314,12 @@ class FieldComparatorTest(unittest.TestCase):
             name="Test", options=field_options, resource_database=resource_database
         )
         FieldComparator(
-            field_without_reference, field_with_reference, self.finding_container
+            field_without_reference,
+            field_with_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message, "A resource reference option is added to the field `Test`."
-        )
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -362,12 +345,12 @@ class FieldComparatorTest(unittest.TestCase):
             name="Test", options=field_options, resource_database=resource_database
         )
         FieldComparator(
-            field_without_reference, field_with_reference, self.finding_container
+            field_without_reference,
+            field_with_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message, "A resource reference option is added to the field `Test`."
-        )
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -382,13 +365,12 @@ class FieldComparatorTest(unittest.TestCase):
         # defined in the message.
         field_without_reference = make_field(name="Test")
         FieldComparator(
-            field_with_reference, field_without_reference, self.finding_container
+            field_with_reference,
+            field_without_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getActionableFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "A resource reference option of the field `Test` is removed.",
-        )
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -409,13 +391,12 @@ class FieldComparatorTest(unittest.TestCase):
             name="Test", message_resource=message_resource
         )
         FieldComparator(
-            field_with_reference, field_without_reference, self.finding_container
+            field_with_reference,
+            field_without_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getActionableFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "A resource reference option of the field `Test` is removed.",
-        )
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -446,14 +427,13 @@ class FieldComparatorTest(unittest.TestCase):
             message_resource=message_resource,
         )
         FieldComparator(
-            field_with_reference, field_without_reference, self.finding_container
+            field_with_reference,
+            field_without_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         # `bar/{bar}` is not parent resource of `foo/{foo}`.
         finding = self.finding_container.getActionableFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "A resource reference option of the field `Test` is removed.",
-        )
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -475,14 +455,13 @@ class FieldComparatorTest(unittest.TestCase):
             name="Test", message_resource=message_resource
         )
         FieldComparator(
-            field_with_reference, field_without_reference, self.finding_container
+            field_with_reference,
+            field_without_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "A resource reference option of the field `Test` is removed, but added back to the message options.",
-        )
-        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
+        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_MOVED")
         self.assertEqual(finding.change_type.name, "MINOR")
 
     def test_resource_reference_removal_non_breaking2(self):
@@ -512,14 +491,13 @@ class FieldComparatorTest(unittest.TestCase):
         )
         # `bar/{bar}` is the parent resource of `bar/{bar}/foo/{foo}`.
         FieldComparator(
-            field_with_reference, field_without_reference, self.finding_container
+            field_with_reference,
+            field_without_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "A resource reference option of the field `Test` is removed, but added back to the message options.",
-        )
-        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
+        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_MOVED")
         self.assertEqual(finding.change_type.name, "MINOR")
 
     def test_resource_reference_change_same_type_non_breaking(self):
@@ -529,7 +507,10 @@ class FieldComparatorTest(unittest.TestCase):
         )
         field_with_reference = make_field(name="Test", options=field_options)
         FieldComparator(
-            field_with_reference, field_with_reference, self.finding_container
+            field_with_reference,
+            field_with_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()
         # No breaking change should be detected.
@@ -542,7 +523,10 @@ class FieldComparatorTest(unittest.TestCase):
         )
         field_with_reference = make_field(name="Test", options=field_options)
         FieldComparator(
-            field_with_reference, field_with_reference, self.finding_container
+            field_with_reference,
+            field_with_reference,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()
         # No breaking change should be detected.
@@ -560,13 +544,12 @@ class FieldComparatorTest(unittest.TestCase):
         field_with_reference_foo = make_field(name="Test", options=field_options_foo)
         field_with_reference_bar = make_field(name="Test", options=field_options_bar)
         FieldComparator(
-            field_with_reference_foo, field_with_reference_bar, self.finding_container
+            field_with_reference_foo,
+            field_with_reference_bar,
+            self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(
-            finding.message,
-            "The type of resource reference option of the field `Test` is changed from `example.v1/Foo` to `example.v1/Bar`.",
-        )
         self.assertEqual(finding.change_type.name, "MAJOR")
 
     def test_resource_reference_change_type_conversion_non_breaking(self):
@@ -605,6 +588,7 @@ class FieldComparatorTest(unittest.TestCase):
             field_with_reference_child,
             field_with_reference_parent,
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()
         # No breaking change should be detected.
@@ -616,6 +600,7 @@ class FieldComparatorTest(unittest.TestCase):
             field_with_reference_parent,
             field_with_reference_child,
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()
         # No breaking change should be detected.
@@ -657,13 +642,10 @@ class FieldComparatorTest(unittest.TestCase):
             field_with_reference_child,
             field_with_reference_parent,
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_CHANGE")
-        self.assertEqual(
-            finding.message,
-            "The child_type `example.v1/Bar` and type `example.v1/Foo` of resource reference option in field `Test` cannot be resolved to the identical resource.",
-        )
+        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_CHANGE_CHILD_TYPE")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
 

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -26,17 +26,19 @@ class DescriptorComparatorTest(unittest.TestCase):
         self.finding_container = FindingContainer()
 
     def test_message_removal(self):
-        DescriptorComparator(self.message_foo, None, self.finding_container).compare()
+        DescriptorComparator(
+            self.message_foo, None, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "An existing message `Message` is removed.")
         self.assertEqual(finding.category.name, "MESSAGE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
     def test_message_addition(self):
-        DescriptorComparator(None, self.message_foo, self.finding_container).compare()
+        DescriptorComparator(
+            None, self.message_foo, self.finding_container, context="ctx"
+        ).compare()
         finding = self.finding_container.getAllFindings()[0]
-        self.assertEqual(finding.message, "A new message `Message` is added.")
         self.assertEqual(finding.category.name, "MESSAGE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -46,12 +48,14 @@ class DescriptorComparatorTest(unittest.TestCase):
         field_string = make_field(proto_type="TYPE_STRING")
         message1 = make_message(fields=[field_int])
         message2 = make_message(fields=[field_string])
-        DescriptorComparator(message1, message2, self.finding_container).compare()
-        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
-        finding = findings_map[
-            "Type of an existing field `my_field` is changed from `int32` to `string`."
-        ]
-        self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
+        DescriptorComparator(
+            message1, message2, self.finding_container, context="ctx"
+        ).compare()
+        finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "FIELD_TYPE_CHANGE"
+        )
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
@@ -59,7 +63,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         field_int = make_field(proto_type="TYPE_INT32")
         message_update = make_message(fields=[field_int])
         DescriptorComparator(
-            make_message(), message_update, self.finding_container
+            make_message(), message_update, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
@@ -71,6 +75,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             make_message(nested_messages=[make_message(name="nested_message")]),
             make_message(),
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.category.name, "MESSAGE_REMOVAL")
@@ -82,6 +87,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             make_message(),
             make_message(nested_messages=[make_message(name="nested_message")]),
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.category.name, "MESSAGE_ADDITION")
@@ -93,6 +99,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             make_message(),
             make_message(nested_enums=[make_enum(name="nested_message")]),
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
@@ -104,6 +111,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             make_message(nested_enums=[make_enum(name="nested_message")]),
             make_message(),
             self.finding_container,
+            context="ctx",
         ).compare()
         finding = self.finding_container.getAllFindings()[0]
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
@@ -118,10 +126,14 @@ class DescriptorComparatorTest(unittest.TestCase):
         nested_message_without_fields = make_message(name="nested_message")
         message1 = make_message(nested_messages=[nested_message_with_fields])
         message2 = make_message(nested_messages=[nested_message_without_fields])
-        DescriptorComparator(message1, message2, self.finding_container).compare()
-        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
-        finding = findings_map["An existing field `nested_field` is removed."]
-        self.assertEqual(finding.category.name, "FIELD_REMOVAL")
+        DescriptorComparator(
+            message1, message2, self.finding_container, context="ctx"
+        ).compare()
+        finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "FIELD_REMOVAL"
+        )
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
@@ -143,10 +155,14 @@ class DescriptorComparatorTest(unittest.TestCase):
         )
         message1 = make_message(nested_enums=[nested_enum1])
         message2 = make_message(nested_enums=[nested_enum2])
-        DescriptorComparator(message1, message2, self.finding_container).compare()
-        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
-        finding = findings_map["A new EnumValue `BLUE` is added."]
-        self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
+        DescriptorComparator(
+            message1, message2, self.finding_container, context="ctx"
+        ).compare()
+        finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "ENUM_VALUE_ADDITION"
+        )
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
 

--- a/test/comparator/test_resources.py
+++ b/test/comparator/test_resources.py
@@ -52,50 +52,44 @@ class ResourceReferenceTest(unittest.TestCase):
             FileSet(_INVOKER_UPDATE.get_descriptor_set()),
             self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
-        # An existing pattern of a file-level resource definition is changed.
-        file_resource_pattern_change = findings_map[
-            "An existing pattern value of the resource definition `example.googleapis.com/t2` is updated from `foo/{foo}/bar/{bar}/t2` to `foo/{foo}/bar/{bar}/t2_update`."
-        ]
-        self.assertEqual(
-            file_resource_pattern_change.category.name, "RESOURCE_PATTERN_CHANGE"
+
+        addition_finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "RESOURCE_PATTERN_ADDITION"
+        )
+        removal_finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "RESOURCE_PATTERN_REMOVAL"
+        )
+        resource_definition_removal_finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "RESOURCE_DEFINITION_REMOVAL"
         )
         self.assertEqual(
-            file_resource_pattern_change.location.proto_file_name,
-            "resource_database_v1beta1.proto",
-        )
-        self.assertEqual(file_resource_pattern_change.location.source_code_line, 13)
-        # An existing pattern of a message-level resource annotation is changed.
-        message_resource_pattern_change = findings_map[
-            "An existing pattern value of the resource definition `example.googleapis.com/Foo` is updated from `foo/{foo}/bar/{bar}` to `foo/{foo}/bar`."
-        ]
-        self.assertEqual(
-            message_resource_pattern_change.category.name,
-            "RESOURCE_PATTERN_CHANGE",
-        )
-        self.assertEqual(
-            message_resource_pattern_change.location.proto_file_name,
-            "resource_database_v1beta1.proto",
-        )
-        self.assertEqual(
-            message_resource_pattern_change.location.source_code_line,
-            26,
-        )
-        # An existing message-level resource annotation is removed, and it is not moved to
-        # file-level resource definition. So it is a breaking change.
-        message_resource_removal = findings_map[
-            "An existing resource definition `example.googleapis.com/Test` has been removed."
-        ]
-        self.assertEqual(
-            message_resource_removal.category.name,
-            "RESOURCE_DEFINITION_REMOVAL",
-        )
-        self.assertEqual(
-            message_resource_removal.location.proto_file_name,
+            addition_finding.location.proto_file_name,
             "resource_database_v1.proto",
         )
-        self.assertEqual(message_resource_removal.location.source_code_line, 34)
-        self.assertEqual(message_resource_removal.change_type.value, 1)
+        self.assertEqual(addition_finding.location.source_code_line, 13)
+
+        self.assertEqual(
+            removal_finding.location.proto_file_name,
+            "resource_database_v1.proto",
+        )
+        self.assertEqual(
+            removal_finding.location.source_code_line,
+            13,
+        )
+        self.assertEqual(
+            resource_definition_removal_finding.location.proto_file_name,
+            "resource_database_v1.proto",
+        )
+        self.assertEqual(
+            resource_definition_removal_finding.location.source_code_line, 34
+        )
+        self.assertEqual(resource_definition_removal_finding.change_type.value, 1)
 
     def test_resource_reference_change(self):
         _INVOKER_ORIGNAL = Loader(
@@ -115,13 +109,11 @@ class ResourceReferenceTest(unittest.TestCase):
             FileSet(_INVOKER_UPDATE.get_descriptor_set()),
             self.finding_container,
         ).compare()
-        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
-        # Type of the resource_reference is changed from type to child_type, but
-        # they can not be resoved to the identical resource. Breaking change.
-        finding = findings_map[
-            "The child_type `example.googleapis.com/t1` and type `example.googleapis.com/t1` of resource reference option in field `topic` cannot be resolved to the identical resource."
-        ]
-        self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_CHANGE")
+        finding = next(
+            f
+            for f in self.finding_container.getAllFindings()
+            if f.category.name == "RESOURCE_REFERENCE_CHANGE_CHILD_TYPE"
+        )
         self.assertEqual(
             finding.location.proto_file_name, "resource_reference_v1beta1.proto"
         )

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -22,7 +22,7 @@ from test.tools.mock_descriptors import (
     make_enum,
 )
 from src.detector.options import Options
-from src.findings.utils import Finding
+from src.findings.finding import Finding
 
 
 class DectetorTest(unittest.TestCase):
@@ -77,7 +77,7 @@ class DectetorTest(unittest.TestCase):
             ).detect_breaking_changes()
             self.assertEqual(
                 fakeOutput.getvalue(),
-                "my_proto.proto L2: An existing rpc method `DoThing` is removed.\n"
+                "my_proto.proto L2: An existing method `DoThing` is removed from service `Placeholder`.\n"
                 + "my_proto.proto L6: An existing message `input` is removed.\n"
                 + "my_proto.proto L12: An existing message `output` is removed.\n",
             )
@@ -98,7 +98,7 @@ class DectetorTest(unittest.TestCase):
         ).detect_breaking_changes()
         # Without options, the detector returns an array of actionable Findings.
         self.assertEqual(
-            breaking_changes[0].message, "An existing Enum `foo` is removed."
+            breaking_changes[0].getMessage(), "An existing enum `foo` is removed."
         )
 
 

--- a/test/findings/test_finding_container.py
+++ b/test/findings/test_finding_container.py
@@ -14,7 +14,7 @@
 
 import unittest
 from src.findings.finding_container import FindingContainer
-from src.findings.utils import FindingCategory, ChangeType
+from src.findings.finding_category import FindingCategory, ChangeType
 
 
 class FindingContainerTest(unittest.TestCase):
@@ -29,8 +29,9 @@ class FindingContainerTest(unittest.TestCase):
             category=FindingCategory.METHOD_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=12,
-            message="An rpc method bar is removed.",
             change_type=ChangeType.MAJOR,
+            subject="subject",
+            context="context",
         )
         self.assertEqual(len(self.finding_container.getAllFindings()), 1)
 
@@ -39,7 +40,6 @@ class FindingContainerTest(unittest.TestCase):
             category=FindingCategory.FIELD_ADDITION,
             proto_file_name="my_proto.proto",
             source_code_line=15,
-            message="Not breaking change.",
             change_type=ChangeType.MINOR,
         )
         self.assertEqual(len(self.finding_container.getActionableFindings()), 1)
@@ -51,24 +51,26 @@ class FindingContainerTest(unittest.TestCase):
 
     def test4_toHumanReadableMessage(self):
         self.finding_container.addFinding(
-            category=FindingCategory.RESOURCE_DEFINITION_CHANGE,
+            category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=5,
-            message="An existing file-level resource definition has changed.",
             change_type=ChangeType.MAJOR,
+            subject="subject",
         )
         self.finding_container.addFinding(
-            category=FindingCategory.METHOD_SIGNATURE_CHANGE,
+            category=FindingCategory.METHOD_SIGNATURE_REMOVAL,
             proto_file_name="my_other_proto.proto",
             source_code_line=-1,
-            message="An existing method_signature is changed from 'sig1' to 'sig2'.",
             change_type=ChangeType.MAJOR,
+            type="type",
+            subject="subject",
+            context="context",
         )
         self.assertEqual(
             self.finding_container.toHumanReadableMessage(),
-            "my_proto.proto L5: An existing file-level resource definition has changed.\n"
-            + "my_proto.proto L12: An rpc method bar is removed.\n"
-            + "my_other_proto.proto: An existing method_signature is changed from 'sig1' to 'sig2'.\n",
+            "my_other_proto.proto: An existing method_signature `type` is removed from method `subject` in service `context`.\n"
+            + "my_proto.proto L5: An existing resource_definition `subject` is removed.\n"
+            + "my_proto.proto L12: An existing method `subject` is removed from service `context`.\n",
         )
 
 


### PR DESCRIPTION
Refactor the message logic.

1. Make messages context-aware
2. Store all messages in the same place. Messages should not be elsewhere in the code.
3. Refactor tests. Remove "change-detector tests".

There are two commits; please review the code commit separately, since test commit adds a lot of noise.

- code changes: adding context, refactoring some checks, and introducing new messages: [commit](https://github.com/googleapis/proto-breaking-change-detector/pull/180/commits/30221e047fee277be9699e9dbce8745b06c7ac39)
- test changes: mostly removing useless comparisons of message strings, which are in fact change-detector tests: [commit](https://github.com/googleapis/proto-breaking-change-detector/pull/180/commits/2a0afda80236773bb287d455651169483729bc98)