### PR TITLE
refactor: use snake_case instead of camelCase for field and method names

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -79,7 +79,7 @@ def detect(
         output_json_path,
     )
     # 3. Create protoc command (back up solution) to load the FileDescriptorSet.
-    # It takes options, returns fileDescriptorSet.
+    # It takes options, returns file_descriptor_set.
     if options.use_descriptor_set():
         file_set_original = Loader(
             proto_definition_dirs=None,

--- a/src/comparator/enum_comparator.py
+++ b/src/comparator/enum_comparator.py
@@ -35,7 +35,7 @@ class EnumComparator:
         # 1. If the original EnumDescriptor is None,
         # then a new EnumDescriptor is added.
         if self.enum_original is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.ENUM_ADDITION,
                 proto_file_name=self.enum_update.proto_file_name,
                 source_code_line=self.enum_update.source_code_line,
@@ -47,7 +47,7 @@ class EnumComparator:
         # 2. If the updated EnumDescriptor is None,
         # then the original EnumDescriptor is removed.
         elif self.enum_update is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.ENUM_REMOVAL,
                 proto_file_name=self.enum_original.proto_file_name,
                 source_code_line=self.enum_original.source_code_line,

--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -33,7 +33,7 @@ class EnumValueComparator:
     def compare(self):
         # 1. If the original EnumValue is None, then a new EnumValue is added.
         if self.enum_value_original is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.ENUM_VALUE_ADDITION,
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,
@@ -43,7 +43,7 @@ class EnumValueComparator:
             )
         # 2. If the updated EnumValue is None, then the original EnumValue is removed.
         elif self.enum_value_update is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.ENUM_VALUE_REMOVAL,
                 proto_file_name=self.enum_value_original.proto_file_name,
                 source_code_line=self.enum_value_original.source_code_line,
@@ -53,7 +53,7 @@ class EnumValueComparator:
             )
         # 3. If both EnumValueDescriptors are existing, check if the name is identical.
         elif self.enum_value_original.name != self.enum_value_update.name:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.ENUM_VALUE_NAME_CHANGE,
                 proto_file_name=self.enum_value_update.proto_file_name,
                 source_code_line=self.enum_value_update.source_code_line,

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -39,7 +39,7 @@ class FieldComparator:
         # 1. If original FieldDescriptor is None, then a
         # new FieldDescriptor is added.
         if self.field_original is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.FIELD_ADDITION,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.source_code_line,
@@ -52,7 +52,7 @@ class FieldComparator:
         # 2. If updated FieldDescriptor is None, then
         # the original FieldDescriptor is removed.
         if self.field_update is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.FIELD_REMOVAL,
                 proto_file_name=self.field_original.proto_file_name,
                 source_code_line=self.field_original.source_code_line,
@@ -65,7 +65,7 @@ class FieldComparator:
         # 3. If both FieldDescriptors are existing, check
         # if the name is changed.
         if self.field_original.name != self.field_update.name:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.FIELD_NAME_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.source_code_line,
@@ -80,7 +80,7 @@ class FieldComparator:
         # 4. If the FieldDescriptors have the same name, check if the
         # repeated state of them stay the same.
         if self.field_original.repeated.value != self.field_update.repeated.value:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.FIELD_REPEATED_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.repeated.source_code_line,
@@ -91,7 +91,7 @@ class FieldComparator:
             )
         # Field option change from optional to required is breaking.
         if not self.field_original.required.value and self.field_update.required.value:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.FIELD_BEHAVIOR_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.required.source_code_line,
@@ -103,7 +103,7 @@ class FieldComparator:
             )
         # 5. Check the type of the field.
         if self.field_original.proto_type.value != self.field_update.proto_type.value:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.FIELD_TYPE_CHANGE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=self.field_update.proto_type.source_code_line,
@@ -129,7 +129,7 @@ class FieldComparator:
                 not transformed_type_name
                 or transformed_type_name != self.field_update.type_name.value
             ):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
@@ -146,7 +146,7 @@ class FieldComparator:
             if self.field_original.is_map_type and not self.field_update.is_map_type:
                 key_original = self.field_original.map_entry_type["key"]
                 value_original = self.field_original.map_entry_type["value"]
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
@@ -160,7 +160,7 @@ class FieldComparator:
             elif not self.field_original.is_map_type and self.field_update.is_map_type:
                 key_update = self.field_update.map_entry_type["key"]
                 value_update = self.field_update.map_entry_type["value"]
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_TYPE_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.type_name.source_code_line,
@@ -188,7 +188,7 @@ class FieldComparator:
                     or self._transformed_type_name(value_original) == value_update
                 )
                 if not (identical_key_type and identical_value_type):
-                    self.finding_container.addFinding(
+                    self.finding_container.add_finding(
                         category=FindingCategory.FIELD_TYPE_CHANGE,
                         proto_file_name=self.field_update.proto_file_name,
                         source_code_line=self.field_update.type_name.source_code_line,
@@ -205,7 +205,7 @@ class FieldComparator:
             proto_file_name = self.field_update.proto_file_name
             source_code_line = self.field_update.source_code_line
             if self.field_original.oneof:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_ONEOF_MOVE_OUT,
                     proto_file_name=proto_file_name,
                     source_code_line=source_code_line,
@@ -215,7 +215,7 @@ class FieldComparator:
                     extra_info=self.field_update.nested_path,
                 )
             else:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_ONEOF_MOVE_IN,
                     proto_file_name=proto_file_name,
                     source_code_line=source_code_line,
@@ -230,7 +230,7 @@ class FieldComparator:
             and self.field_original.proto3_optional != self.field_update.proto3_optional
         ):
             if self.field_original.proto3_optional:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_PROTO3_OPTIONAL_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.source_code_line,
@@ -240,7 +240,7 @@ class FieldComparator:
                     extra_info=self.field_update.nested_path,
                 )
             if self.field_update.proto3_optional:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.FIELD_PROTO3_OPTIONAL_CHANGE,
                     proto_file_name=self.field_update.proto_file_name,
                     source_code_line=self.field_update.source_code_line,
@@ -266,7 +266,7 @@ class FieldComparator:
             resource_in_database = self._resource_in_database(resource_ref_update)
             # If the new resource reference is not in the database, breaking change.
             if not resource_in_database:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_REFERENCE_ADDITION,
                     proto_file_name=field_update.proto_file_name,
                     source_code_line=resource_ref_update.source_code_line,
@@ -278,7 +278,7 @@ class FieldComparator:
                 )
             # If the new resource reference is in the database, no breaking change.
             else:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_REFERENCE_ADDITION,
                     proto_file_name=field_update.proto_file_name,
                     source_code_line=resource_ref_update.source_code_line,
@@ -290,7 +290,7 @@ class FieldComparator:
         # Resource annotation is removed, check if it is added as a message resource.
         if resource_ref_original and not resource_ref_update:
             if not self._resource_ref_in_local(resource_ref_original.value):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_REFERENCE_REMOVAL,
                     proto_file_name=field_original.proto_file_name,
                     source_code_line=resource_ref_original.source_code_line,
@@ -299,7 +299,7 @@ class FieldComparator:
                     change_type=ChangeType.MAJOR,
                 )
             else:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_REFERENCE_MOVED,
                     proto_file_name=field_original.proto_file_name,
                     source_code_line=resource_ref_original.source_code_line,
@@ -319,7 +319,7 @@ class FieldComparator:
                 resource_ref_update.value.type or resource_ref_update.value.child_type
             )
             if original_type != update_type:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_REFERENCE_CHANGE,
                     proto_file_name=field_update.proto_file_name,
                     source_code_line=resource_ref_update.source_code_line,
@@ -414,7 +414,7 @@ class FieldComparator:
             parent_resources = rb_update.get_parent_resources_by_child_type(child_type)
         if not any(parent.value.type == parent_type for parent in parent_resources):
             # Resulting referenced resource patterns cannot be resolved identical.
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.RESOURCE_REFERENCE_CHANGE_CHILD_TYPE,
                 proto_file_name=self.field_update.proto_file_name,
                 source_code_line=source_code_line,

--- a/src/comparator/file_set_comparator.py
+++ b/src/comparator/file_set_comparator.py
@@ -64,7 +64,7 @@ class FileSetComparator:
                     per_language_options_original - per_language_options_update
                 ):
                     classname_option = packaging_options_original[option][classname]
-                    self.finding_container.addFinding(
+                    self.finding_container.add_finding(
                         category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                         proto_file_name=classname_option.proto_file_name,
                         source_code_line=classname_option.source_code_line,
@@ -91,7 +91,7 @@ class FileSetComparator:
                     namespace_option = packaging_options_original[option][
                         original_option_value
                     ]
-                    self.finding_container.addFinding(
+                    self.finding_container.add_finding(
                         category=FindingCategory.PACKAGING_OPTION_REMOVAL,
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
@@ -106,7 +106,7 @@ class FileSetComparator:
                     namespace_option = packaging_options_update[option][
                         original_option_value
                     ]
-                    self.finding_container.addFinding(
+                    self.finding_container.add_finding(
                         category=FindingCategory.PACKAGING_OPTION_ADDITION,
                         proto_file_name=namespace_option.proto_file_name,
                         source_code_line=namespace_option.source_code_line,
@@ -239,7 +239,7 @@ class FileSetComparator:
             patterns_update = resources_update.types[resource_type].value.pattern
             # A new pattern is added.
             for pattern in set(patterns_update) - set(patterns_original):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_PATTERN_ADDITION,
                     proto_file_name=resources_original.types[
                         resource_type
@@ -253,7 +253,7 @@ class FileSetComparator:
                 )
             # An existing pattern is removed.
             for pattern in set(patterns_original) - set(patterns_update):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.RESOURCE_PATTERN_REMOVAL,
                     proto_file_name=resources_original.types[
                         resource_type
@@ -268,7 +268,7 @@ class FileSetComparator:
 
         # 2. File-level resource definitions addition.
         for resource_type in resources_types_update - resources_types_original:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.RESOURCE_DEFINITION_ADDITION,
                 proto_file_name=resources_update.types[resource_type].proto_file_name,
                 source_code_line=resources_update.types[resource_type].source_code_line,
@@ -277,7 +277,7 @@ class FileSetComparator:
             )
         # 3. File-level resource definitions removal.
         for resource_type in resources_types_original - resources_types_update:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
                 proto_file_name=resources_original.types[resource_type].proto_file_name,
                 source_code_line=resources_original.types[

--- a/src/comparator/message_comparator.py
+++ b/src/comparator/message_comparator.py
@@ -39,7 +39,7 @@ class DescriptorComparator:
     def _compare(self, message_original, message_update):
         # 1. If original message is None, then a new message is added.
         if message_original is None and message_update:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.MESSAGE_ADDITION,
                 proto_file_name=message_update.proto_file_name,
                 source_code_line=message_update.source_code_line,
@@ -49,7 +49,7 @@ class DescriptorComparator:
             return
         # 2. If updated message is None, then the original message is removed.
         if message_update is None and message_original:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.MESSAGE_REMOVAL,
                 proto_file_name=message_original.proto_file_name,
                 source_code_line=message_original.source_code_line,
@@ -92,24 +92,24 @@ class DescriptorComparator:
         fields_number_original = set(fields_dict_original.keys())
         fields_number_update = set(fields_dict_update.keys())
 
-        for fieldNumber in fields_number_original - fields_number_update:
+        for field_number in fields_number_original - fields_number_update:
             FieldComparator(
-                fields_dict_original[fieldNumber],
+                fields_dict_original[field_number],
                 None,
                 self.finding_container,
                 context=self.context,
             ).compare()
-        for fieldNumber in fields_number_update - fields_number_original:
+        for field_number in fields_number_update - fields_number_original:
             FieldComparator(
                 None,
-                fields_dict_update[fieldNumber],
+                fields_dict_update[field_number],
                 self.finding_container,
                 context=self.context,
             ).compare()
-        for fieldNumber in fields_number_original & fields_number_update:
+        for field_number in fields_number_original & fields_number_update:
             FieldComparator(
-                fields_dict_original[fieldNumber],
-                fields_dict_update[fieldNumber],
+                fields_dict_original[field_number],
+                fields_dict_update[field_number],
                 self.finding_container,
                 context=self.context,
             ).compare()
@@ -120,14 +120,14 @@ class DescriptorComparator:
         message_name_original = set(nested_msg_dict_original.keys())
         message_name_update = set(nested_msg_dict_update.keys())
 
-        for msgName in message_name_original - message_name_update:
-            self._compare(nested_msg_dict_original[msgName], None)
-        for msgName in message_name_update - message_name_original:
-            self._compare(None, nested_msg_dict_update[msgName])
-        for msgName in message_name_update & message_name_original:
+        for message_name in message_name_original - message_name_update:
+            self._compare(nested_msg_dict_original[message_name], None)
+        for message_name in message_name_update - message_name_original:
+            self._compare(None, nested_msg_dict_update[message_name])
+        for message_name in message_name_update & message_name_original:
             self._compare(
-                nested_msg_dict_original[msgName],
-                nested_msg_dict_update[msgName],
+                nested_msg_dict_original[message_name],
+                nested_msg_dict_update[message_name],
             )
 
     def _compare_nested_enums(self, nested_enum_dict_original, nested_enum_dict_update):

--- a/src/comparator/resource_database.py
+++ b/src/comparator/resource_database.py
@@ -18,7 +18,7 @@ from typing import Sequence
 class ResourceDatabase:
     # Create resource database for file-level and messasge-level resouce definitions.
     # It has two dictionaries: types map and patterns map. Register a resource will put
-    # [typeStr, resource_messsage] in types dict, and [pattern0, resource_message]
+    # [type_str, resource_message] in types dict, and [pattern0, resource_message]
     # [pattern1, ressource_message] (if it has multiple patterns) in patterns dict."""
     def __init__(self):
         self.types = {}

--- a/src/comparator/service_comparator.py
+++ b/src/comparator/service_comparator.py
@@ -33,7 +33,7 @@ class ServiceComparator:
     def compare(self):
         # 1. If original service is None, then a new service is added.
         if self.service_original is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.SERVICE_ADDITION,
                 proto_file_name=self.service_update.proto_file_name,
                 source_code_line=self.service_update.source_code_line,
@@ -43,7 +43,7 @@ class ServiceComparator:
             return
         # 2. If updated service is None, then the original service is removed.
         if self.service_update is None:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.SERVICE_REMOVAL,
                 proto_file_name=self.service_original.proto_file_name,
                 source_code_line=self.service_original.source_code_line,
@@ -56,14 +56,14 @@ class ServiceComparator:
         # 4. Check the oauth scopes list.
         self._compare_oauth_scopes()
         # 5. Check the methods list
-        self._compareRpcMethods()
+        self._compare_rpc_methods()
 
     def _compare_host(self):
         if not self.service_original.host and not self.service_update.host:
             return
         if not self.service_original.host:
             host = self.service_update.host
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.SERVICE_HOST_ADDITION,
                 proto_file_name=host.proto_file_name,
                 source_code_line=host.source_code_line,
@@ -74,7 +74,7 @@ class ServiceComparator:
             return
         if not self.service_update.host:
             host = self.service_original.host
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.SERVICE_HOST_REMOVAL,
                 proto_file_name=host.proto_file_name,
                 source_code_line=host.source_code_line,
@@ -86,7 +86,7 @@ class ServiceComparator:
         host_original = self.service_original.host
         host_update = self.service_update.host
         if host_original.value != host_update.value:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.SERVICE_HOST_CHANGE,
                 proto_file_name=host_update.proto_file_name,
                 source_code_line=host_update.source_code_line,
@@ -110,7 +110,7 @@ class ServiceComparator:
         for scope in set(oauth_scopes_update.keys()) - set(
             oauth_scopes_original.keys()
         ):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.OAUTH_SCOPE_ADDITION,
                 proto_file_name=self.service_original.proto_file_name,
                 source_code_line=oauth_scopes_update[scope].source_code_line,
@@ -121,7 +121,7 @@ class ServiceComparator:
         for scope in set(oauth_scopes_original.keys()) - set(
             oauth_scopes_update.keys()
         ):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.OAUTH_SCOPE_REMOVAL,
                 proto_file_name=self.service_original.proto_file_name,
                 source_code_line=oauth_scopes_original[scope].source_code_line,
@@ -130,7 +130,7 @@ class ServiceComparator:
                 change_type=ChangeType.MAJOR,
             )
 
-    def _compareRpcMethods(self):
+    def _compare_rpc_methods(self):
         methods_original = self.service_original.methods
         methods_update = self.service_update.methods
         methods_original_keys = set(methods_original.keys())
@@ -138,7 +138,7 @@ class ServiceComparator:
         # 3.1 An RPC method is removed.
         for name in methods_original_keys - methods_update_keys:
             removed_method = methods_original[name]
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.METHOD_REMOVAL,
                 proto_file_name=removed_method.proto_file_name,
                 source_code_line=removed_method.source_code_line,
@@ -149,7 +149,7 @@ class ServiceComparator:
         # 3.2 An RPC method is added.
         for name in methods_update_keys - methods_original_keys:
             added_method = methods_update[name]
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.METHOD_ADDTION,
                 proto_file_name=added_method.proto_file_name,
                 source_code_line=added_method.source_code_line,
@@ -168,7 +168,7 @@ class ServiceComparator:
                 and self._get_version_update_name(input_type_original)
                 != input_type_update
             ):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.METHOD_INPUT_TYPE_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.input.source_code_line,
@@ -190,7 +190,7 @@ class ServiceComparator:
                 and self._get_version_update_name(response_type_original)
                 != response_type_update
             ):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.METHOD_RESPONSE_TYPE_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.output.source_code_line,
@@ -209,7 +209,7 @@ class ServiceComparator:
                 method_original.client_streaming.value
                 != method_update.client_streaming.value
             ):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.METHOD_CLIENT_STREAMING_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.client_streaming.source_code_line,
@@ -226,7 +226,7 @@ class ServiceComparator:
                 method_original.server_streaming.value
                 != method_update.server_streaming.value
             ):
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.METHOD_SERVER_STREAMING_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.server_streaming.source_code_line,
@@ -246,7 +246,7 @@ class ServiceComparator:
                     or method_original.paged_result_field.name
                     != method_update.paged_result_field.name
                 ):
-                    self.finding_container.addFinding(
+                    self.finding_container.add_finding(
                         category=FindingCategory.METHOD_PAGINATED_RESPONSE_CHANGE,
                         proto_file_name=method_update.proto_file_name,
                         source_code_line=method_update.source_code_line,
@@ -279,7 +279,7 @@ class ServiceComparator:
             # except for bi-directional streaming RPCs, so the http_annotation addition/removal indicates
             # streaming state changes of the RPC, which is a breaking change.
             if http_annotation_original and not http_annotation_update:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.HTTP_ANNOTATION_REMOVAL,
                     proto_file_name=method_original.proto_file_name,
                     source_code_line=method_original.http_annotation.source_code_line,
@@ -288,7 +288,7 @@ class ServiceComparator:
                     change_type=ChangeType.MAJOR,
                 )
             if not http_annotation_original and http_annotation_update:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.HTTP_ANNOTATION_ADDITION,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.http_annotation.source_code_line,
@@ -302,7 +302,7 @@ class ServiceComparator:
             http_annotation_original["http_method"]
             != http_annotation_update["http_method"]
         ):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.HTTP_ANNOTATION_CHANGE,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=method_update.http_annotation.source_code_line,
@@ -319,7 +319,7 @@ class ServiceComparator:
             )
         # Compare http body, they should be identical.
         if http_annotation_original["http_body"] != http_annotation_update["http_body"]:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.HTTP_ANNOTATION_CHANGE,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=method_update.http_annotation.source_code_line,
@@ -339,7 +339,7 @@ class ServiceComparator:
             annotation_value = http_annotation_original["http_uri"]
             transformed_value = self._get_version_update_name(annotation_value)
             if transformed_value != http_annotation_update["http_uri"]:
-                self.finding_container.addFinding(
+                self.finding_container.add_finding(
                     category=FindingCategory.HTTP_ANNOTATION_CHANGE,
                     proto_file_name=method_update.proto_file_name,
                     source_code_line=method_update.http_annotation.source_code_line,
@@ -362,7 +362,7 @@ class ServiceComparator:
             return
         # LRO operation_info annotation addition.
         if not lro_original:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.LRO_ANNOTATION_ADDITION,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=method_update.lro_annotation.source_code_line,
@@ -373,7 +373,7 @@ class ServiceComparator:
             return
         # LRO operation_info annotation removal.
         if not lro_update:
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.LRO_ANNOTATION_REMOVAL,
                 proto_file_name=method_original.proto_file_name,
                 source_code_line=method_original.lro_annotation.source_code_line,
@@ -388,7 +388,7 @@ class ServiceComparator:
             and self._get_version_update_name(lro_original.value["response_type"])
             != lro_update.value["response_type"]
         ):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.LRO_RESPONSE_CHANGE,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=lro_update.source_code_line,
@@ -410,7 +410,7 @@ class ServiceComparator:
             and self._get_version_update_name(lro_original.value["metadata_type"])
             != lro_update.value["metadata_type"]
         ):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.LRO_METADATA_CHANGE,
                 proto_file_name=method_update.proto_file_name,
                 source_code_line=lro_update.source_code_line,
@@ -431,7 +431,7 @@ class ServiceComparator:
         signatures_original = method_original.method_signatures.value
         signatures_update = method_update.method_signatures.value
         for sig in set(signatures_update) - set(signatures_original):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.METHOD_SIGNATURE_ADDITION,
                 proto_file_name=method_original.proto_file_name,
                 source_code_line=method_original.method_signatures.source_code_line,
@@ -441,7 +441,7 @@ class ServiceComparator:
                 change_type=ChangeType.MINOR,
             )
         for sig in set(signatures_original) - set(signatures_update):
-            self.finding_container.addFinding(
+            self.finding_container.add_finding(
                 category=FindingCategory.METHOD_SIGNATURE_REMOVAL,
                 proto_file_name=method_original.proto_file_name,
                 source_code_line=method_original.method_signatures.source_code_line,

--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -61,7 +61,7 @@ class EnumValue:
 
     enum_value_pb: the descriptor of EnumValue.
     proto_file_name: the proto file where the EnumValue exists.
-    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    source_code_locations: the dictionary that contains all the source_code_info in the file_descriptor_set.
     path: the path to the EnumValue, by querying the above dictionary using the path,
           we can get the location information.
     """
@@ -87,7 +87,7 @@ class Enum:
 
     enum_pb: the descriptor of Enum.
     proto_file_name: the proto file where the Enum exists.
-    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    source_code_locations: the dictionary that contains all the source_code_info in the file_descriptor_set.
     path: the path to the Enum, by querying the above dictionary using the path,
           we can get the location information.
     """
@@ -134,7 +134,7 @@ class Field:
 
     field_pb: the descriptor of Field.
     proto_file_name: the proto file where the Field exists.
-    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    source_code_locations: the dictionary that contains all the source_code_info in the file_descriptor_set.
     path: the path to the Field, by querying the above dictionary using the path,
           we can get the location information.
     resource_database: global resource database that contains all file-level resource definitions
@@ -343,7 +343,7 @@ class Message:
 
     message_pb: the descriptor of Message.
     proto_file_name: the proto file where the Message exists.
-    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    source_code_locations: the dictionary that contains all the source_code_info in the file_descriptor_set.
     path: the path to the Message, by querying the above dictionary using the path,
           we can get the location information.
     resource_database: global resource database that contains all file-level resource definitions
@@ -431,7 +431,7 @@ class Message:
 
     @property
     def nested_messages(self) -> Dict[str, "Message"]:
-        """Return the nested messsages in the message. Message is identified by name."""
+        """Return the nested messages in the message. Message is identified by name."""
         nested_messages_map = {}
         for i, message in enumerate(self.message_pb.nested_type):
             # Exclude the auto-generated map_entries message, since
@@ -462,7 +462,7 @@ class Message:
     @property
     def map_entries(self) -> Dict[str, Dict[str, Field]]:
         # If the nested message is auto-generated map entry for the maps field,
-        # the message name is fieldName + 'Entry', and it has two nested fields (key, value).
+        # the message name is field_name + 'Entry', and it has two nested fields (key, value).
         #
         # For maps fields:
         # map<KeyType, ValueType> map_field = 1;
@@ -543,7 +543,7 @@ class Method:
     messages_map: the map that contains all messages defined in the API definition files and
                   the dependencies. The key is message name, and value is the Message class.
     proto_file_name: the proto file where the Method exists.
-    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    source_code_locations: the dictionary that contains all the source_code_info in the file_descriptor_set.
     path: the path to the Method, by querying the above dictionary using the path,
           we can get the location information.
     """
@@ -621,7 +621,7 @@ class Method:
             return None
         if not self.messages_map or self.output.value not in self.messages_map:
             return None
-        # API should provide a `string next_page_token` field in response messsage.
+        # API should provide a `string next_page_token` field in response message.
         # API should provide `int page_size` and `string page_token` fields in request message.
         # If the request field lacks any of the expected pagination fields,
         # then the method is not paginated.
@@ -733,7 +733,7 @@ class Service:
     messages_map: the map that contains all messages defined in the API definition files and
                   the dependencies. The key is message name, and value is the Message class.
     proto_file_name: the proto file where the Service exists.
-    source_code_locations: the dictionary that contains all the sourceCodeInfo in the fileDescriptorSet.
+    source_code_locations: the dictionary that contains all the source_code_info in the file_descriptor_set.
     path: the path to the MethServiceod, by querying the above dictionary using the path,
           we can get the location information.
     api_version: the version of the API definition files.
@@ -828,7 +828,7 @@ class Service:
 
 
 class FileSet:
-    """Description of a fileSet.
+    """Description of a file_set.
 
     file_set_pb: The FileDescriptorSet object that is obtained by proto compiler.
     """
@@ -1005,7 +1005,7 @@ class FileSet:
     def _get_root_package(self) -> str:
         dependency_map = defaultdict(list)
         for fd in self.file_set_pb.file:
-            # Put the fileDescriptor and its dependencies to the dependency map.
+            # Put the file descriptor and its dependencies to the dependency map.
             for dep in fd.dependency:
                 dependency_map[dep].append(fd)
         # Find the root API definition file.

--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -48,9 +48,11 @@ class Detector:
             # Output json file of findings and human-readable messages if the
             # command line option is enabled.
             with open(self.opts.output_json_path, "w") as write_json_file:
-                json.dump(self.finding_container.toDictArr(), write_json_file, indent=2)
+                json.dump(
+                    self.finding_container.to_dict_arr(), write_json_file, indent=2
+                )
 
         if self.opts and self.opts.human_readable_message:
-            sys.stdout.write(self.finding_container.toHumanReadableMessage())
+            sys.stdout.write(self.finding_container.to_human_readable_message())
 
-        return self.finding_container.getActionableFindings()
+        return self.finding_container.get_actionable_findings()

--- a/src/findings/finding.py
+++ b/src/findings/finding.py
@@ -48,7 +48,7 @@ class Finding:
         self.type = type
         self.oldtype = oldtype
 
-    def toDict(self):
+    def to_dict(self):
         return {
             "category": self.category.name,
             "location": {
@@ -64,6 +64,6 @@ class Finding:
             "oldtype": self.oldtype,
         }
 
-    def getMessage(self):
-        format_parameters = self.toDict()
+    def get_message(self):
+        format_parameters = self.to_dict()
         return templates[self.category].format(**format_parameters)

--- a/src/findings/finding_container.py
+++ b/src/findings/finding_container.py
@@ -19,7 +19,7 @@ from src.findings.finding_category import FindingCategory, ChangeType
 from collections import defaultdict
 
 
-def sortedFilteredFindings(findings: list, filter: Callable) -> list:
+def sorted_filtered_findings(findings: list, filter: Callable) -> list:
     filtered = [f for f in findings if filter(f)]
     filtered.sort(
         key=lambda f: (
@@ -39,7 +39,7 @@ class FindingContainer:
     def __init__(self):
         self.finding_results = []
 
-    def addFinding(
+    def add_finding(
         self,
         category: FindingCategory,
         proto_file_name: str,
@@ -67,21 +67,21 @@ class FindingContainer:
             )
         )
 
-    def getAllFindings(self):
-        return sortedFilteredFindings(self.finding_results, lambda f: True)
+    def get_all_findings(self):
+        return sorted_filtered_findings(self.finding_results, lambda f: True)
 
-    def getActionableFindings(self):
-        return sortedFilteredFindings(
+    def get_actionable_findings(self):
+        return sorted_filtered_findings(
             self.finding_results, lambda f: f.change_type == ChangeType.MAJOR
         )
 
-    def toDictArr(self):
-        return [finding.toDict() for finding in self.finding_results]
+    def to_dict_arr(self):
+        return [finding.to_dict() for finding in self.finding_results]
 
-    def toHumanReadableMessage(self):
+    def to_human_readable_message(self):
         output_message = ""
         file_to_findings = defaultdict(list)
-        for finding in self.getActionableFindings():
+        for finding in self.get_actionable_findings():
             # Create a map to summarize the findings based on proto file name.
             file_to_findings[finding.location.proto_file_name].append(finding)
         # Add each finding to the output message.
@@ -89,9 +89,9 @@ class FindingContainer:
             # Customize sort key function to output the findings in the same
             # file based on the source code line number.
             # Sort message alphabetically if the line number is same.
-            sorted_findings = sortedFilteredFindings(findings, lambda f: True)
+            sorted_findings = sorted_filtered_findings(findings, lambda f: True)
             for finding in sorted_findings:
-                message = finding.getMessage()
+                message = finding.get_message()
                 if finding.location.source_code_line == -1:
                     output_message += f"{file_name}: {message}\n"
                 else:

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -127,7 +127,7 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "service_v1.proto L11: An existing method `shouldRemove` is removed from service `Example`.\n"
+                "service_v1.proto L11: An existing method `ShouldRemove` is removed from service `Example`.\n"
                 + "service_v1.proto L21: An existing field `page_size` is removed from message `.example.v1.BarRequest`.\n"
                 + "service_v1.proto L22: An existing field `page_token` is removed from message `.example.v1.BarRequest`.\n"
                 + "service_v1.proto L26: An existing field `content` is removed from message `.example.v1.BarResponse`.\n"
@@ -136,7 +136,7 @@ class CliDetectTest(unittest.TestCase):
                 + "service_v1beta1.proto L7: Response type of method `Foo` is changed from `.example.v1.FooResponse` to `.example.v1beta1.FooResponseUpdate` in service `Example`.\n"
                 + "service_v1beta1.proto L9: Client streaming flag is changed for method `Bar` in service `Example`.\n"
                 + "service_v1beta1.proto L9: Server streaming flag is changed for method `Bar` in service `Example`.\n"
-                + "service_v1beta1.proto L11: Pagination feature is changed for method `paginatedMethod` in service `Example`.\n",
+                + "service_v1beta1.proto L11: Pagination feature is changed for method `PaginatedMethod` in service `Example`.\n",
             )
 
     def test_single_directory_service_annotation(self):

--- a/test/comparator/test_enum_comparator.py
+++ b/test/comparator/test_enum_comparator.py
@@ -54,7 +54,7 @@ class EnumComparatorTest(unittest.TestCase):
         EnumComparator(
             self.enum_foo, None, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
@@ -64,7 +64,7 @@ class EnumComparatorTest(unittest.TestCase):
         EnumComparator(
             None, self.enum_bar, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
@@ -74,7 +74,7 @@ class EnumComparatorTest(unittest.TestCase):
         EnumComparator(
             self.enum_foo, self.enum_bar, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
@@ -84,7 +84,7 @@ class EnumComparatorTest(unittest.TestCase):
         EnumComparator(
             self.enum_foo, self.enum_foo, self.finding_container, context="ctx"
         ).compare()
-        self.assertEqual(len(self.finding_container.getAllFindings()), 0)
+        self.assertEqual(len(self.finding_container.get_all_findings()), 0)
 
 
 if __name__ == "__main__":

--- a/test/comparator/test_enum_value_comparator.py
+++ b/test/comparator/test_enum_value_comparator.py
@@ -46,7 +46,7 @@ class EnumValueComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_VALUE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
@@ -56,7 +56,7 @@ class EnumValueComparatorTest(unittest.TestCase):
         EnumValueComparator(
             None, self.enum_foo, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_VALUE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "test.proto")
@@ -66,7 +66,7 @@ class EnumValueComparatorTest(unittest.TestCase):
         EnumValueComparator(
             self.enum_foo, self.enum_bar, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_VALUE_NAME_CHANGE")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "test_update.proto")
@@ -76,7 +76,7 @@ class EnumValueComparatorTest(unittest.TestCase):
         EnumValueComparator(
             self.enum_foo, self.enum_foo, self.finding_container, context="ctx"
         ).compare()
-        self.assertEqual(len(self.finding_container.getAllFindings()), 0)
+        self.assertEqual(len(self.finding_container.get_all_findings()), 0)
 
 
 if __name__ == "__main__":

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -35,7 +35,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_foo, None, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
@@ -44,7 +44,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             None, field_foo, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
 
     def test_name_change(self):
@@ -53,7 +53,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_foo, field_bar, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_NAME_CHANGE")
 
     def test_repeated_label_change(self):
@@ -62,7 +62,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_repeated, field_non_repeated, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_REPEATED_CHANGE")
 
     def test_field_behavior_change(self):
@@ -72,13 +72,13 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_required, field_non_required, self.finding_container, context="ctx"
         ).compare()
-        findings = self.finding_container.getAllFindings()
+        findings = self.finding_container.get_all_findings()
         self.assertFalse(findings)
         # Required to optional, non-breaking change.
         FieldComparator(
             field_non_required, field_required, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_BEHAVIOR_CHANGE")
 
     def test_primitive_type_change(self):
@@ -87,7 +87,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_int, field_string, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
 
     def test_message_type_change(self):
@@ -96,7 +96,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_message, field_message_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
 
     def test_message_type_change_minor_version_update(self):
@@ -107,7 +107,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_message, field_message_update, self.finding_container, context="ctx"
         ).compare()
-        findings = self.finding_container.getAllFindings()
+        findings = self.finding_container.get_all_findings()
         self.assertFalse(findings)
 
     def test_type_change_map_entry1(self):
@@ -130,7 +130,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_no_map, field_map, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -155,7 +155,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_map, field_no_map, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -186,7 +186,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_original, field_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -220,7 +220,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_original, field_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()
+        finding = self.finding_container.get_all_findings()
         self.assertFalse(finding)
 
     def test_out_oneof(self):
@@ -231,7 +231,7 @@ class FieldComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "FIELD_ONEOF_MOVE_OUT"
         )
         self.assertTrue(finding)
@@ -244,7 +244,7 @@ class FieldComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "FIELD_ONEOF_MOVE_IN"
         )
         self.assertTrue(finding)
@@ -260,7 +260,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_optional, field_not_optional, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_PROTO3_OPTIONAL_CHANGE")
 
     def test_proto3_required_to_optional(self):
@@ -274,7 +274,7 @@ class FieldComparatorTest(unittest.TestCase):
         FieldComparator(
             field_not_optional, field_optional, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_PROTO3_OPTIONAL_CHANGE")
 
     def test_resource_reference_addition_breaking(self):
@@ -293,7 +293,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_ADDITION")
 
     def test_resource_reference_type_addition_non_breaking(self):
@@ -319,7 +319,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -350,7 +350,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -370,7 +370,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getActionableFindings()[0]
+        finding = self.finding_container.get_actionable_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -396,7 +396,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getActionableFindings()[0]
+        finding = self.finding_container.get_actionable_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -433,7 +433,7 @@ class FieldComparatorTest(unittest.TestCase):
             context="ctx",
         ).compare()
         # `bar/{bar}` is not parent resource of `foo/{foo}`.
-        finding = self.finding_container.getActionableFindings()[0]
+        finding = self.finding_container.get_actionable_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -460,7 +460,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_MOVED")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -496,7 +496,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_MOVED")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -512,7 +512,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()
+        finding = self.finding_container.get_all_findings()
         # No breaking change should be detected.
         self.assertFalse(finding)
 
@@ -528,7 +528,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()
+        finding = self.finding_container.get_all_findings()
         # No breaking change should be detected.
         self.assertFalse(finding)
 
@@ -549,7 +549,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
 
     def test_resource_reference_change_type_conversion_non_breaking(self):
@@ -590,7 +590,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()
+        finding = self.finding_container.get_all_findings()
         # No breaking change should be detected.
         self.assertFalse(finding)
 
@@ -602,7 +602,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()
+        finding = self.finding_container.get_all_findings()
         # No breaking change should be detected.
         self.assertFalse(finding)
 
@@ -644,7 +644,7 @@ class FieldComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "RESOURCE_REFERENCE_CHANGE_CHILD_TYPE")
         self.assertEqual(finding.change_type.name, "MAJOR")
 

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -49,7 +49,7 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(),
             self.finding_container,
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
 
     def test_service_addition(self):
@@ -65,7 +65,7 @@ class FileSetComparatorTest(unittest.TestCase):
             file_set,
             self.finding_container,
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "SERVICE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -94,7 +94,7 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(files=[make_file_pb2(services=[service_update])]),
             self.finding_container,
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "METHOD_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "my_proto.proto")
@@ -109,7 +109,7 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(files=[make_file_pb2(messages=[message_update])]),
             self.finding_container,
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_NAME_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "my_proto.proto")
@@ -157,7 +157,7 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         # The breaking change should be in field level, instead of message removal,
         # since the message is imported from dependency file.
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "update.proto")
@@ -183,7 +183,7 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(files=[make_file_pb2(enums=[enum_update])]),
             self.finding_container,
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_VALUE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "my_proto.proto")
@@ -232,7 +232,7 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         # The breaking change should be in field level, instead of message removal,
         # since the message is imported from dependency file.
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "FIELD_TYPE_CHANGE")
         self.assertEqual(finding.location.proto_file_name, "update.proto")
@@ -258,7 +258,7 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.change_type.name == "MAJOR"
         )
         self.assertEqual(finding.category.name, "RESOURCE_PATTERN_REMOVAL")
@@ -288,7 +288,7 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             file_set_original, file_set_update, self.finding_container
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.category.name, "RESOURCE_PATTERN_REMOVAL")
         self.assertEqual(
@@ -311,7 +311,7 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             file_set_original, file_set_update, self.finding_container
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(
             finding.category.name,
@@ -346,7 +346,7 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         file_resource_removal = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "RESOURCE_DEFINITION_REMOVAL"
         )
         self.assertEqual(
@@ -379,7 +379,7 @@ class FileSetComparatorTest(unittest.TestCase):
         FileSetComparator(
             file_set_original, file_set_update, self.finding_container
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "PACKAGING_OPTION_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -413,13 +413,13 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         java_classname_option_removal = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "PACKAGING_OPTION_REMOVAL"
             and f.subject == "java_outer_classname"
         )
         php_namespace_option_removal = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "PACKAGING_OPTION_REMOVAL"
             and f.subject == "php_namespace"
         )
@@ -456,7 +456,7 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(files=[file_update]),
             self.finding_container,
         ).compare()
-        self.assertTrue(len(self.finding_container.getAllFindings()) == 0)
+        self.assertTrue(len(self.finding_container.get_all_findings()) == 0)
 
 
 if __name__ == "__main__":

--- a/test/comparator/test_message_comparator.py
+++ b/test/comparator/test_message_comparator.py
@@ -29,7 +29,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         DescriptorComparator(
             self.message_foo, None, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "MESSAGE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -38,7 +38,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         DescriptorComparator(
             None, self.message_foo, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "MESSAGE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -53,7 +53,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "FIELD_TYPE_CHANGE"
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
@@ -65,7 +65,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         DescriptorComparator(
             make_message(), message_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -77,7 +77,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "MESSAGE_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -89,7 +89,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "MESSAGE_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -101,7 +101,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -113,7 +113,7 @@ class DescriptorComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "ENUM_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -131,7 +131,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "FIELD_REMOVAL"
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
@@ -160,7 +160,7 @@ class DescriptorComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "ENUM_VALUE_ADDITION"
         )
         self.assertEqual(finding.change_type.name, "MINOR")

--- a/test/comparator/test_resources.py
+++ b/test/comparator/test_resources.py
@@ -55,17 +55,17 @@ class ResourceReferenceTest(unittest.TestCase):
 
         addition_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "RESOURCE_PATTERN_ADDITION"
         )
         removal_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "RESOURCE_PATTERN_REMOVAL"
         )
         resource_definition_removal_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "RESOURCE_DEFINITION_REMOVAL"
         )
         self.assertEqual(
@@ -111,7 +111,7 @@ class ResourceReferenceTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "RESOURCE_REFERENCE_CHANGE_CHILD_TYPE"
         )
         self.assertEqual(
@@ -123,7 +123,7 @@ class ResourceReferenceTest(unittest.TestCase):
         # but it is added in message-level. Non-breaking change.
         # 2. File-level resource definition `t2` is removed, but is added
         # to message-level resource. Non-breaking change.
-        breaking_changes = self.finding_container.getActionableFindings()
+        breaking_changes = self.finding_container.get_actionable_findings()
         self.assertEqual(len(breaking_changes), 1)
 
 

--- a/test/comparator/test_service_comparator.py
+++ b/test/comparator/test_service_comparator.py
@@ -18,7 +18,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ServiceComparator(
             self.service_foo, None, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "SERVICE_REMOVAL")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
@@ -26,7 +26,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ServiceComparator(
             None, self.service_foo, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "SERVICE_ADDITION")
         self.assertEqual(finding.location.proto_file_name, "foo")
 
@@ -39,7 +39,7 @@ class ServiceComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "SERVICE_HOST_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -53,7 +53,7 @@ class ServiceComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "SERVICE_HOST_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -64,7 +64,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ServiceComparator(
             service_original, service_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "SERVICE_HOST_CHANGE")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -81,14 +81,14 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "OAUTH_SCOPE_REMOVAL"
             and f.subject == "https://foo/user/"
         )
         self.assertEqual(finding.location.proto_file_name, "foo")
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "OAUTH_SCOPE_REMOVAL"
             and f.subject == "https://foo/admin/"
         )
@@ -103,7 +103,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ServiceComparator(
             service_original, service_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "METHOD_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -116,7 +116,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ServiceComparator(
             service_original, service_update, self.finding_container, context="ctx"
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "METHOD_ADDTION")
         self.assertEqual(finding.change_type.name, "MINOR")
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -135,7 +135,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "METHOD_INPUT_TYPE_CHANGE"
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
@@ -167,7 +167,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "METHOD_RESPONSE_TYPE_CHANGE"
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
@@ -186,13 +186,13 @@ class ServiceComparatorTest(unittest.TestCase):
 
         client_streaming_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "METHOD_CLIENT_STREAMING_CHANGE"
         )
         self.assertEqual(client_streaming_finding.location.proto_file_name, "foo")
         server_streaming_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "METHOD_SERVER_STREAMING_CHANGE"
         )
         self.assertEqual(server_streaming_finding.change_type.name, "MAJOR")
@@ -237,7 +237,7 @@ class ServiceComparatorTest(unittest.TestCase):
             ".example.v1.PaginatedRequestMessage": paginated_request_message,
         }
         paged_method = make_method(
-            name="notInteresting",
+            name="NotInteresting",
             input_message=paginated_request_message,
             output_message=paginated_response_message,
         )
@@ -249,7 +249,7 @@ class ServiceComparatorTest(unittest.TestCase):
                 name="MethodOutput", full_name=".example.v1alpha.MethodOutput"
             ),
         }
-        non_paged_method = make_method(name="notInteresting")
+        non_paged_method = make_method(name="NotInteresting")
         service_original = make_service(
             methods=(paged_method,), messages_map=messages_map_original
         )
@@ -261,7 +261,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "METHOD_PAGINATED_RESPONSE_CHANGE"
         )
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -270,18 +270,18 @@ class ServiceComparatorTest(unittest.TestCase):
         ServiceComparator(
             make_service(
                 methods=(
-                    make_method(name="notInteresting", signatures=["sig1", "sig2"]),
+                    make_method(name="NotInteresting", signatures=["sig1", "sig2"]),
                 )
             ),
             make_service(
-                methods=(make_method(name="notInteresting", signatures=["sig1"]),)
+                methods=(make_method(name="NotInteresting", signatures=["sig1"]),)
             ),
             self.finding_container,
             context="ctx",
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "METHOD_SIGNATURE_REMOVAL"
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
@@ -309,7 +309,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "LRO_ANNOTATION_ADDITION"
         )
         self.assertTrue(finding)
@@ -336,7 +336,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "LRO_ANNOTATION_REMOVAL"
         )
         self.assertTrue(finding)
@@ -368,7 +368,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "LRO_ANNOTATION_REMOVAL"
         )
         self.assertTrue(finding)
@@ -398,7 +398,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "LRO_RESPONSE_CHANGE"
         )
         self.assertEqual(finding.change_type.name, "MAJOR")
@@ -429,7 +429,7 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "LRO_METADATA_CHANGE"
         )
         self.assertEqual(finding.location.proto_file_name, "foo")
@@ -449,7 +449,7 @@ class ServiceComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "HTTP_ANNOTATION_ADDITION")
         self.assertEqual(finding.change_type.name, "MINOR")
 
@@ -468,7 +468,7 @@ class ServiceComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        finding = self.finding_container.getAllFindings()[0]
+        finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "HTTP_ANNOTATION_REMOVAL")
         self.assertEqual(finding.change_type.name, "MAJOR")
 
@@ -491,12 +491,12 @@ class ServiceComparatorTest(unittest.TestCase):
         ).compare()
         uri_change_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "HTTP_ANNOTATION_CHANGE" and f.type == "http_uri"
         )
         body_change_finding = next(
             f
-            for f in self.finding_container.getAllFindings()
+            for f in self.finding_container.get_all_findings()
             if f.category.name == "HTTP_ANNOTATION_CHANGE" and f.type == "http_body"
         )
         self.assertEqual(
@@ -525,7 +525,7 @@ class ServiceComparatorTest(unittest.TestCase):
             self.finding_container,
             context="ctx",
         ).compare()
-        findings_map = {f.message: f for f in self.finding_container.getAllFindings()}
+        findings_map = {f.message: f for f in self.finding_container.get_all_findings()}
         # No breaking changes, since only minor version update in the http URI.
         self.assertFalse(findings_map)
 

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -71,12 +71,12 @@ class DectetorTest(unittest.TestCase):
                     update_descriptor_set_file_path=None,
                     human_readable_message=True,
                 )
-        with mock.patch("sys.stdout", new=StringIO()) as fakeOutput:
+        with mock.patch("sys.stdout", new=StringIO()) as fake_output:
             result = Detector(
                 file_set_original, file_set_update, opts
             ).detect_breaking_changes()
             self.assertEqual(
-                fakeOutput.getvalue(),
+                fake_output.getvalue(),
                 "my_proto.proto L2: An existing method `DoThing` is removed from service `Placeholder`.\n"
                 + "my_proto.proto L6: An existing message `input` is removed.\n"
                 + "my_proto.proto L12: An existing message `output` is removed.\n",
@@ -98,7 +98,7 @@ class DectetorTest(unittest.TestCase):
         ).detect_breaking_changes()
         # Without options, the detector returns an array of actionable Findings.
         self.assertEqual(
-            breaking_changes[0].getMessage(), "An existing enum `foo` is removed."
+            breaking_changes[0].get_message(), "An existing enum `foo` is removed."
         )
 
 

--- a/test/findings/test_finding_container.py
+++ b/test/findings/test_finding_container.py
@@ -25,7 +25,7 @@ class FindingContainerTest(unittest.TestCase):
     finding_container = FindingContainer()
 
     def test1_add_findings(self):
-        self.finding_container.addFinding(
+        self.finding_container.add_finding(
             category=FindingCategory.METHOD_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=12,
@@ -33,31 +33,31 @@ class FindingContainerTest(unittest.TestCase):
             subject="subject",
             context="context",
         )
-        self.assertEqual(len(self.finding_container.getAllFindings()), 1)
+        self.assertEqual(len(self.finding_container.get_all_findings()), 1)
 
     def test2_get_actionable_findings(self):
-        self.finding_container.addFinding(
+        self.finding_container.add_finding(
             category=FindingCategory.FIELD_ADDITION,
             proto_file_name="my_proto.proto",
             source_code_line=15,
             change_type=ChangeType.MINOR,
         )
-        self.assertEqual(len(self.finding_container.getActionableFindings()), 1)
+        self.assertEqual(len(self.finding_container.get_actionable_findings()), 1)
 
-    def test3_toDictArr(self):
-        dict_arr_output = self.finding_container.toDictArr()
+    def test3_to_dict_arr(self):
+        dict_arr_output = self.finding_container.to_dict_arr()
         self.assertEqual(dict_arr_output[0]["category"], "METHOD_REMOVAL")
         self.assertEqual(dict_arr_output[1]["category"], "FIELD_ADDITION")
 
-    def test4_toHumanReadableMessage(self):
-        self.finding_container.addFinding(
+    def test4_to_human_readable_message(self):
+        self.finding_container.add_finding(
             category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=5,
             change_type=ChangeType.MAJOR,
             subject="subject",
         )
-        self.finding_container.addFinding(
+        self.finding_container.add_finding(
             category=FindingCategory.METHOD_SIGNATURE_REMOVAL,
             proto_file_name="my_other_proto.proto",
             source_code_line=-1,
@@ -67,7 +67,7 @@ class FindingContainerTest(unittest.TestCase):
             context="context",
         )
         self.assertEqual(
-            self.finding_container.toHumanReadableMessage(),
+            self.finding_container.to_human_readable_message(),
             "my_other_proto.proto: An existing method_signature `type` is removed from method `subject` in service `context`.\n"
             + "my_proto.proto L5: An existing resource_definition `subject` is removed.\n"
             + "my_proto.proto L12: An existing method `subject` is removed from service `context`.\n",

--- a/test/testdata/protos/service/v1/service_v1.proto
+++ b/test/testdata/protos/service/v1/service_v1.proto
@@ -8,9 +8,9 @@ service Example {
 
   rpc Bar(FooRequest) returns (FooResponse) {}
 
-  rpc shouldRemove(FooRequest) returns (FooResponse) {}
+  rpc ShouldRemove(FooRequest) returns (FooResponse) {}
 
-  rpc paginatedMethod(BarRequest) returns (BarResponse) {}
+  rpc PaginatedMethod(BarRequest) returns (BarResponse) {}
 }
 
 message FooRequest {}

--- a/test/testdata/protos/service/v1beta1/service_v1beta1.proto
+++ b/test/testdata/protos/service/v1beta1/service_v1beta1.proto
@@ -8,7 +8,7 @@ service Example {
 
   rpc Bar(stream FooRequest) returns (stream FooResponse) {}
 
-  rpc paginatedMethod(BarRequest) returns (BarResponse) {}
+  rpc PaginatedMethod(BarRequest) returns (BarResponse) {}
 }
 
 message FooRequest {}


### PR DESCRIPTION
Fixes #181. I'm only making naming changes in this PR, no other code, logical, or test changes.