### PR TITLE
feat: --no_line_numbers disables lines numbers output

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -53,6 +53,12 @@ from src.detector.detector import Detector
     is_flag=True,
     help="Enable the human-readable message output if set to True. Default value is false.",
 )
+@click.option(
+    "--line_numbers/--no_line_numbers",
+    default=True,
+    is_flag=True,
+    help="Show line numbers in the human readable output. True by default, use --no_line_numbers to disable.",
+)
 def detect(
     original_api_definition_dirs: str,
     update_api_definition_dirs: str,
@@ -62,6 +68,7 @@ def detect(
     update_descriptor_set_file_path: str,
     output_json_path: str,
     human_readable_message: bool,
+    line_numbers: bool,
 ):
     """Detect the breaking changes of the original and updated versions of API definition files."""
     # 1. Read the stdin options and create the Options object for all the command args.
@@ -69,14 +76,15 @@ def detect(
     # a) proto API defintion files.
     # b) compiled FileDescriptorSet file which can be obtained by protocal compiler.
     options = Options(
-        original_api_definition_dirs,
-        update_api_definition_dirs,
-        original_proto_files,
-        update_proto_files,
-        original_descriptor_set_file_path,
-        update_descriptor_set_file_path,
-        human_readable_message,
-        output_json_path,
+        original_api_definition_dirs=original_api_definition_dirs,
+        update_api_definition_dirs=update_api_definition_dirs,
+        original_proto_files=original_proto_files,
+        update_proto_files=update_proto_files,
+        original_descriptor_set_file_path=original_descriptor_set_file_path,
+        update_descriptor_set_file_path=update_descriptor_set_file_path,
+        human_readable_message=human_readable_message,
+        output_json_path=output_json_path,
+        line_numbers=line_numbers,
     )
     # 3. Create protoc command (back up solution) to load the FileDescriptorSet.
     # It takes options, returns file_descriptor_set.

--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -53,6 +53,10 @@ class Detector:
                 )
 
         if self.opts and self.opts.human_readable_message:
-            sys.stdout.write(self.finding_container.to_human_readable_message())
+            sys.stdout.write(
+                self.finding_container.to_human_readable_message(
+                    line_numbers=self.opts.line_numbers
+                )
+            )
 
         return self.finding_container.get_actionable_findings()

--- a/src/detector/options.py
+++ b/src/detector/options.py
@@ -32,6 +32,7 @@ class Options:
     output_json_path: Optional. The path of the findings json file. If not specify,
                       we will create a json for the users which is in
                       `$root/detected_breaking_changes.json`.
+    line_numbers: Show line numbers from the human readable output. True by default.
     """
 
     def __init__(
@@ -44,6 +45,7 @@ class Options:
         update_descriptor_set_file_path: str,
         human_readable_message: bool = False,
         output_json_path: Optional[str] = None,
+        line_numbers: bool = True,
     ):
         self.original_api_definition_dirs = self._get_arg_arr(
             original_api_definition_dirs
@@ -60,6 +62,7 @@ class Options:
             )
         self.human_readable_message = human_readable_message
         self.output_json_path = self._get_output_json_path(output_json_path)
+        self.line_numbers = line_numbers
 
     def use_proto_dirs(self) -> bool:
         # User pass in the directorirs of proto definition files as input.

--- a/src/findings/finding_container.py
+++ b/src/findings/finding_container.py
@@ -78,7 +78,7 @@ class FindingContainer:
     def to_dict_arr(self):
         return [finding.to_dict() for finding in self.finding_results]
 
-    def to_human_readable_message(self):
+    def to_human_readable_message(self, line_numbers=True):
         output_message = ""
         file_to_findings = defaultdict(list)
         for finding in self.get_actionable_findings():
@@ -92,7 +92,7 @@ class FindingContainer:
             sorted_findings = sorted_filtered_findings(findings, lambda f: True)
             for finding in sorted_findings:
                 message = finding.get_message()
-                if finding.location.source_code_line == -1:
+                if finding.location.source_code_line == -1 or not line_numbers:
                     output_message += f"{file_name}: {message}\n"
                 else:
                     output_message += (

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -288,6 +288,32 @@ class CliDetectTest(unittest.TestCase):
                 + "google/cloud/texttospeech/v1beta1/cloud_tts.proto L283: An existing message `Timepoint` is removed.\n",
             )
 
+    def test_tts_proto_no_line_numbers(self):
+        with patch("sys.stdout", new=StringIO()):
+            runner = CliRunner()
+            result = runner.invoke(
+                detect,
+                [
+                    f"--original_api_definition_dirs=googleapis/,{self.COMMON_PROTOS_DIR}",
+                    f"--update_api_definition_dirs=googleapis/,{self.COMMON_PROTOS_DIR}",
+                    "--original_proto_files=googleapis/google/cloud/texttospeech/v1beta1/cloud_tts.proto",
+                    "--update_proto_files=googleapis/google/cloud/texttospeech/v1/cloud_tts.proto",
+                    "--human_readable_message",
+                    "--no_line_numbers",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing value `MP3_64_KBPS` is removed from enum `AudioEncoding`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing value `MULAW` is removed from enum `AudioEncoding`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing enum `TimepointType` is removed.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing field `enable_time_pointing` is removed from message `.google.cloud.texttospeech.v1beta1.SynthesizeSpeechRequest`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing field `timepoints` is removed from message `.google.cloud.texttospeech.v1beta1.SynthesizeSpeechResponse`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing field `audio_config` is removed from message `.google.cloud.texttospeech.v1beta1.SynthesizeSpeechResponse`.\n"
+                + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing message `Timepoint` is removed.\n",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Sometimes line numbers do not make sense since they belong to some temporary and invisible proto file and confuse the users. Since we now emit messages with context, line numbers can be dropped in such cases.