### PR TITLE
fix: fix the logic for finding package name

### DIFF
--- a/src/comparator/wrappers.py
+++ b/src/comparator/wrappers.py
@@ -1018,7 +1018,7 @@ class FileSet:
         """
         Return the package name of the API being checked.
 
-        In this code, we don't have an access to "file_to_generate" boolean flag.
+        In this code we don't have an access to "file_to_generate" boolean flag.
         We only have parsed proto files in a FileDescriptorSet.
         So the idea is to find which files are not listed as imports of any other
         proto files (are "roots" of the dependency tree) and take the common prefix

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -1,3 +1,6 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -8,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unittest
 import os
 import tempfile

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -132,13 +132,13 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(
                 files=[
                     make_file_pb2(
-                        name="orignal.proto",
+                        name="original.proto",
                         messages=[message_original],
-                        dependency="test/import/dep.proto",
+                        dependency=["test/import/dep.proto"],
                         package="example.v1",
                     ),
                     make_file_pb2(
-                        name="dep.proto",
+                        name="test/import/dep.proto",
                         messages=[field_type_original],
                         package="test.import",
                     ),
@@ -206,13 +206,13 @@ class FileSetComparatorTest(unittest.TestCase):
             make_file_set(
                 files=[
                     make_file_pb2(
-                        name="orignal.proto",
+                        name="original.proto",
                         messages=[message_original],
-                        dependency="test/import/dep.proto",
+                        dependency=["test/import/dep.proto"],
                         package="example.v1",
                     ),
                     make_file_pb2(
-                        name="dep.proto",
+                        name="test/import/dep.proto",
                         enums=[field_type_original],
                         package="test.import",
                     ),

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -25,6 +25,8 @@ from test.tools.mock_descriptors import (
 from google.api import resource_pb2
 from google.protobuf import descriptor_pb2
 
+from src.comparator.wrappers import FileSet
+
 
 class FileSetTest(unittest.TestCase):
     def test_file_set_properties(self):
@@ -358,6 +360,43 @@ class FileSetTest(unittest.TestCase):
         file_set = make_file_set(files=[dep1, dep2])
         self.assertEqual(file_set.root_package, "example.external")
         self.assertFalse(file_set.api_version)
+
+    def test_get_root_package_with(self):
+        common = descriptor_pb2.FileDescriptorProto(
+            name="google/cloud/common_resources.proto",
+            package="google.cloud",
+        )
+        speech_resource = descriptor_pb2.FileDescriptorProto(
+            name="google/cloud/speech/v1/resource.proto",
+            package="google.cloud.speech.v1",
+        )
+        speech_with_dep = descriptor_pb2.FileDescriptorProto(
+            name="google/cloud/speech/v1/cloud_speech.proto",
+            package="google.cloud.speech.v1",
+            dependency=["google/cloud/speech/v1/resource.proto"],
+        )
+        speech_no_dep = descriptor_pb2.FileDescriptorProto(
+            name="google/cloud/speech/v1/cloud_speech.proto",
+            package="google.cloud.speech.v1",
+        )
+        self.assertEqual(
+            FileSet.get_root_package(
+                descriptor_pb2.FileDescriptorSet(
+                    file=[common, speech_with_dep, speech_resource]
+                )
+            ),
+            "google.cloud.speech.v1",
+        )
+        self.assertEqual(
+            FileSet.get_root_package(
+                descriptor_pb2.FileDescriptorSet(file=[common, speech_no_dep])
+            ),
+            "google.cloud.speech.v1",
+        )
+        self.assertEqual(
+            FileSet.get_root_package(descriptor_pb2.FileDescriptorSet(file=[common])),
+            "",
+        )
 
 
 if __name__ == "__main__":

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -361,7 +361,7 @@ class FileSetTest(unittest.TestCase):
         self.assertEqual(file_set.root_package, "example.external")
         self.assertFalse(file_set.api_version)
 
-    def test_get_root_package_with(self):
+    def test_get_root_package(self):
         common = descriptor_pb2.FileDescriptorProto(
             name="google/cloud/common_resources.proto",
             package="google.cloud",


### PR DESCRIPTION
BCD produced incorrect findings because sometimes the main package name was determined incorrectly. According to the logic, the package name is taken from the proto file that no other protos import (it's a good enough logic given the absense of `file_to_generate` flag), but we also have `google/cloud/common_resources.proto` (which no other proto file import as well), and when executed for [this change](https://github.com/googleapis/googleapis/commit/2b47b241a4a91905d1c953fa445d73fcad8fe73a), the package name was set to either `google.cloud.speech.v1` or just `google.cloud` depending on an order of files in `protoc` invocation, which caused emitting wrong findings.

Fixing that by rewriting the logic of finding the root package name, and adding special unit tests for this method. Also, fixing existing tests that had bugs and did not work.