### PR TITLE
fix: location info for field and enum name changes

### DIFF
--- a/src/comparator/enum_value_comparator.py
+++ b/src/comparator/enum_value_comparator.py
@@ -61,5 +61,5 @@ class EnumValueComparator:
                 oldsubject=self.enum_value_original.name,
                 context=self.context,
                 change_type=ChangeType.MAJOR,
-                extra_info=self.enum_value_update.nested_path,
+                extra_info=self.enum_value_original.nested_path,
             )

--- a/src/comparator/field_comparator.py
+++ b/src/comparator/field_comparator.py
@@ -73,7 +73,7 @@ class FieldComparator:
                 subject=self.field_update.name,
                 context=self.context,
                 change_type=ChangeType.MAJOR,
-                extra_info=self.field_update.nested_path,
+                extra_info=self.field_original.nested_path,
             )
             return
 

--- a/test/comparator/test_field_comparator.py
+++ b/test/comparator/test_field_comparator.py
@@ -48,13 +48,14 @@ class FieldComparatorTest(unittest.TestCase):
         self.assertEqual(finding.category.name, "FIELD_ADDITION")
 
     def test_name_change(self):
-        field_foo = make_field("Foo")
-        field_bar = make_field("Bar")
+        field_foo = make_field("Foo", nested_path=["foo"])
+        field_bar = make_field("Bar", nested_path=["bar"])
         FieldComparator(
             field_foo, field_bar, self.finding_container, context="ctx"
         ).compare()
         finding = self.finding_container.get_all_findings()[0]
         self.assertEqual(finding.category.name, "FIELD_NAME_CHANGE")
+        self.assertEqual(finding.extra_info[0], "foo")
 
     def test_repeated_label_change(self):
         field_repeated = make_field(repeated=True)


### PR DESCRIPTION
`extra_info` contains clues to find the breaking change in the _source_ protos, so it must contain the original field name or enum value, not the updated one.