### PR TITLE
chore: upgrade black to 22.3.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black==20.8b1
+        pip install black==22.3.0
         pip install coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         git submodule init


### PR DESCRIPTION
There is an [issue](https://github.com/psf/black/issues/2964) with `click>=8.1.0` and `black==20.8b1` where the lint session fails with `ImportError: cannot import name '_unicodefun' from 'click'`. The issue has been (fixed)[https://github.com/psf/black/issues/2964] in black version 22.3.0. 