### PR TITLE
chore: fix the release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,5 +1,4 @@
 releaseType: python
 handleGHRelease: true
 primaryBranch: main
-releaseLabels:
-  - "autorelease: published"
+releaseLabel: "autorelease: published"


### PR DESCRIPTION
The label that is added after tagging should be `releaseLabel` according to:
https://github.com/googleapis/repo-automation-bots/tree/main/packages/release-please