### PR TITLE
feat: introduce conventional commit tag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -175,9 +175,9 @@ six==1.16.0 \
     # via
     #   google-auth
     #   grpcio
-urllib3==2.0.2 \
-    --hash=sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc \
-    --hash=sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e
+urllib3==1.26.16 \
+    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
+    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via requests
 
 # WARNING: The following packages were not pinned, but pip requires them to be

--- a/src/proto_bcd/comparator/enum_comparator.py
+++ b/src/proto_bcd/comparator/enum_comparator.py
@@ -14,7 +14,10 @@
 
 from proto_bcd.comparator.enum_value_comparator import EnumValueComparator
 from proto_bcd.findings.finding_container import FindingContainer
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ConventionalCommitTag,
+)
 from proto_bcd.comparator.wrappers import Enum
 
 
@@ -41,7 +44,7 @@ class EnumComparator:
                 source_code_line=self.enum_update.source_code_line,
                 subject=self.enum_update.name,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
 
         # 2. If the updated EnumDescriptor is None,
@@ -53,7 +56,7 @@ class EnumComparator:
                 source_code_line=self.enum_original.source_code_line,
                 subject=self.enum_original.name,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
 
         # 3. If the EnumDescriptors have the same name, check the values

--- a/src/proto_bcd/comparator/enum_value_comparator.py
+++ b/src/proto_bcd/comparator/enum_value_comparator.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from proto_bcd.findings.finding_container import FindingContainer
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ConventionalCommitTag,
+)
 from proto_bcd.comparator.wrappers import EnumValue
 
 
@@ -39,7 +42,7 @@ class EnumValueComparator:
                 source_code_line=self.enum_value_update.source_code_line,
                 subject=self.enum_value_update.name,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
         # 2. If the updated EnumValue is None, then the original EnumValue is removed.
         elif self.enum_value_update is None:
@@ -49,7 +52,7 @@ class EnumValueComparator:
                 source_code_line=self.enum_value_original.source_code_line,
                 subject=self.enum_value_original.name,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
         # 3. If both EnumValueDescriptors are existing, check if the number is identical.
         elif self.enum_value_original.number != self.enum_value_update.number:
@@ -60,6 +63,6 @@ class EnumValueComparator:
                 subject=f"{self.enum_value_update.name} = {self.enum_value_update.number}",
                 oldsubject=f"{self.enum_value_original.name} = {self.enum_value_original.number}",
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=self.enum_value_original.nested_path,
             )

--- a/src/proto_bcd/comparator/file_set_comparator.py
+++ b/src/proto_bcd/comparator/file_set_comparator.py
@@ -18,7 +18,10 @@ from proto_bcd.comparator.message_comparator import DescriptorComparator
 from proto_bcd.comparator.enum_comparator import EnumComparator
 from proto_bcd.comparator.wrappers import FileSet
 from proto_bcd.findings.finding_container import FindingContainer
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ConventionalCommitTag,
+)
 
 
 class FileSetComparator:
@@ -88,7 +91,7 @@ class FileSetComparator:
                             source_code_line=classname_option.source_code_line,
                             type=classname,
                             subject=option,
-                            change_type=ChangeType.MAJOR,
+                            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                         )
             # Compare the option of language namespace. Minor version updates in consideration.
             else:
@@ -126,7 +129,7 @@ class FileSetComparator:
                             source_code_line=namespace_option.source_code_line,
                             type=original_option_value,
                             subject=option,
-                            change_type=ChangeType.MAJOR,
+                            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                         )
                 for namespace in set(transformed_option_value_update.keys()) - set(
                     transformed_option_value_original.keys()
@@ -146,7 +149,7 @@ class FileSetComparator:
                             source_code_line=namespace_option.source_code_line,
                             type=original_option_value,
                             subject=option,
-                            change_type=ChangeType.MAJOR,
+                            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                         )
 
     def _compare_services(self):
@@ -283,7 +286,7 @@ class FileSetComparator:
                     ].source_code_line,
                     type=pattern,
                     subject=resource_type,
-                    change_type=ChangeType.MINOR,
+                    conventional_commit_tag=ConventionalCommitTag.FEAT,
                 )
             # An existing pattern is removed.
             for pattern in set(patterns_original) - set(patterns_update):
@@ -297,7 +300,7 @@ class FileSetComparator:
                     ].source_code_line,
                     type=pattern,
                     subject=resource_type,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 )
 
         # 2. File-level resource definitions addition.
@@ -307,7 +310,7 @@ class FileSetComparator:
                 proto_file_name=resources_update.types[resource_type].proto_file_name,
                 source_code_line=resources_update.types[resource_type].source_code_line,
                 subject=resource_type,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
         # 3. File-level resource definitions removal.
         for resource_type in resources_types_original - resources_types_update:
@@ -318,7 +321,7 @@ class FileSetComparator:
                     resource_type
                 ].source_code_line,
                 subject=resource_type,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
 
     def _get_version_update_name(self, name):

--- a/src/proto_bcd/comparator/message_comparator.py
+++ b/src/proto_bcd/comparator/message_comparator.py
@@ -16,7 +16,10 @@ from proto_bcd.comparator.field_comparator import FieldComparator
 from proto_bcd.comparator.enum_comparator import EnumComparator
 from proto_bcd.comparator.wrappers import Message
 from proto_bcd.findings.finding_container import FindingContainer
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ConventionalCommitTag,
+)
 
 
 class DescriptorComparator:
@@ -44,7 +47,7 @@ class DescriptorComparator:
                 proto_file_name=message_update.proto_file_name,
                 source_code_line=message_update.source_code_line,
                 subject=message_update.name,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
             return
         # 2. If updated message is None, then the original message is removed.
@@ -54,7 +57,7 @@ class DescriptorComparator:
                 proto_file_name=message_original.proto_file_name,
                 source_code_line=message_original.source_code_line,
                 subject=message_original.name,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
             return
         if message_update and message_original:

--- a/src/proto_bcd/comparator/resource_database.py
+++ b/src/proto_bcd/comparator/resource_database.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence
-
 
 class ResourceDatabase:
     # Create resource database for file-level and messasge-level resouce definitions.

--- a/src/proto_bcd/comparator/service_comparator.py
+++ b/src/proto_bcd/comparator/service_comparator.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from proto_bcd.findings.finding_container import FindingContainer
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ConventionalCommitTag,
+)
 from proto_bcd.comparator.wrappers import Service
 
 
@@ -38,7 +41,7 @@ class ServiceComparator:
                 proto_file_name=self.service_update.proto_file_name,
                 source_code_line=self.service_update.source_code_line,
                 subject=self.service_update.name,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
             return
         # 2. If updated service is None, then the original service is removed.
@@ -48,7 +51,7 @@ class ServiceComparator:
                 proto_file_name=self.service_original.proto_file_name,
                 source_code_line=self.service_original.source_code_line,
                 subject=self.service_original.name,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
             return
         # 3. Check the default host.
@@ -69,7 +72,7 @@ class ServiceComparator:
                 source_code_line=host.source_code_line,
                 subject=host.value,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
             return
         if not self.service_update.host:
@@ -80,7 +83,7 @@ class ServiceComparator:
                 source_code_line=host.source_code_line,
                 subject=host.value,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
             return
         host_original = self.service_original.host
@@ -93,7 +96,7 @@ class ServiceComparator:
                 subject=host_update.value,
                 oldsubject=host_original.value,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=[
                     "service " + self.service_update.name + " {",
                     "option (google.api.default_host)",
@@ -116,7 +119,7 @@ class ServiceComparator:
                 source_code_line=oauth_scopes_update[scope].source_code_line,
                 subject=scope,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
         for scope in set(oauth_scopes_original.keys()) - set(
             oauth_scopes_update.keys()
@@ -127,7 +130,7 @@ class ServiceComparator:
                 source_code_line=oauth_scopes_original[scope].source_code_line,
                 subject=scope,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
 
     def _compare_rpc_methods(self):
@@ -144,7 +147,7 @@ class ServiceComparator:
                 source_code_line=removed_method.source_code_line,
                 subject=name,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
         # 3.2 An RPC method is added.
         for name in methods_update_keys - methods_original_keys:
@@ -155,7 +158,7 @@ class ServiceComparator:
                 source_code_line=added_method.source_code_line,
                 subject=name,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
         for name in methods_update_keys & methods_original_keys:
             method_original = methods_original[name]
@@ -176,7 +179,7 @@ class ServiceComparator:
                     context=self.context,
                     oldtype=input_type_original,
                     type=input_type_update,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                     extra_info=[
                         "service " + self.service_update.name + " {",
                         f"rpc {name}",
@@ -198,7 +201,7 @@ class ServiceComparator:
                     context=self.context,
                     oldtype=response_type_original,
                     type=response_type_update,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                     extra_info=[
                         "service " + self.service_update.name + " {",
                         f"rpc {name}",
@@ -215,7 +218,7 @@ class ServiceComparator:
                     source_code_line=method_update.client_streaming.source_code_line,
                     subject=name,
                     context=self.context,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                     extra_info=[
                         "service " + self.service_update.name + " {",
                         f"rpc {name}",
@@ -232,7 +235,7 @@ class ServiceComparator:
                     source_code_line=method_update.server_streaming.source_code_line,
                     subject=name,
                     context=self.context,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                     extra_info=[
                         "service " + self.service_update.name + " {",
                         f"rpc {name}",
@@ -252,7 +255,7 @@ class ServiceComparator:
                         source_code_line=method_update.source_code_line,
                         subject=name,
                         context=self.context,
-                        change_type=ChangeType.MAJOR,
+                        conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                         extra_info=[
                             "service " + self.service_update.name + " {",
                             f"rpc {name}",
@@ -285,7 +288,7 @@ class ServiceComparator:
                     source_code_line=method_original.http_annotation.source_code_line,
                     subject=method_original.name,
                     context=self.context,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 )
             if not http_annotation_original and http_annotation_update:
                 self.finding_container.add_finding(
@@ -294,7 +297,7 @@ class ServiceComparator:
                     source_code_line=method_update.http_annotation.source_code_line,
                     subject=method_update.name,
                     context=self.context,
-                    change_type=ChangeType.MINOR,
+                    conventional_commit_tag=ConventionalCommitTag.FEAT,
                 )
             return
         # Compare http method, they should be identical.
@@ -309,7 +312,7 @@ class ServiceComparator:
                 subject=method_update.name,
                 context=self.context,
                 type="http_method",
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=[
                     "service " + self.service_update.name + " {",
                     f"{method_update.name}",
@@ -326,7 +329,7 @@ class ServiceComparator:
                 subject=method_update.name,
                 context=self.context,
                 type="http_body",
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=[
                     "service " + self.service_update.name + " {",
                     f"{method_update.name}",
@@ -346,7 +349,7 @@ class ServiceComparator:
                     subject=method_update.name,
                     context=self.context,
                     type="http_uri",
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                     extra_info=[
                         "service " + self.service_update.name + " {",
                         f"{method_update.name}",
@@ -368,7 +371,7 @@ class ServiceComparator:
                 source_code_line=method_update.lro_annotation.source_code_line,
                 subject=method_update.name,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
             return
         # LRO operation_info annotation removal.
@@ -379,7 +382,7 @@ class ServiceComparator:
                 source_code_line=method_original.lro_annotation.source_code_line,
                 subject=method_update.name,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             )
             return
         # The response_type value of LRO operation_info is changed.
@@ -396,7 +399,7 @@ class ServiceComparator:
                 context=self.context,
                 oldtype=lro_original.value["response_type"],
                 type=lro_update.value["response_type"],
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=[
                     "service " + self.service_update.name + " {",
                     f"{method_update.name}",
@@ -418,7 +421,7 @@ class ServiceComparator:
                 context=self.context,
                 oldtype=lro_original.value["metadata_type"],
                 type=lro_update.value["metadata_type"],
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=[
                     "service " + self.service_update.name + " {",
                     f"{method_update.name}",
@@ -438,7 +441,7 @@ class ServiceComparator:
                 type=",".join(sig),
                 subject=method_original.name,
                 context=self.context,
-                change_type=ChangeType.MINOR,
+                conventional_commit_tag=ConventionalCommitTag.FEAT,
             )
         removal_reported = False
         for sig in set(signatures_original) - set(signatures_update):
@@ -450,7 +453,7 @@ class ServiceComparator:
                 type=",".join(sig),
                 subject=method_original.name,
                 context=self.context,
-                change_type=ChangeType.MAJOR,
+                conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 extra_info=[
                     "service " + self.service_update.name + " {",
                     f"rpc {method_update.name}",
@@ -470,7 +473,7 @@ class ServiceComparator:
                     type=",".join(sig),
                     subject=method_original.name,
                     context=self.context,
-                    change_type=ChangeType.MAJOR,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                     extra_info=[
                         "service " + self.service_update.name + " {",
                         f"rpc {method_update.name}",

--- a/src/proto_bcd/findings/finding.py
+++ b/src/proto_bcd/findings/finding.py
@@ -31,6 +31,7 @@ class Finding:
         proto_file_name,
         source_code_line,
         change_type,
+        conventional_commit_tag,
         extra_info=None,
         subject="",
         oldsubject="",
@@ -41,6 +42,7 @@ class Finding:
         self.category = category
         self.location = self._Location(proto_file_name, source_code_line)
         self.change_type = change_type
+        self.conventional_commit_tag = conventional_commit_tag
         self.extra_info = extra_info
         self.subject = subject
         self.oldsubject = oldsubject
@@ -56,6 +58,7 @@ class Finding:
                 "source_code_line": self.location.source_code_line,
             },
             "change_type": self.change_type.name,
+            "conventional_commit_tag": self.conventional_commit_tag.name,
             "extra_info": self.extra_info,
             "subject": self.subject,
             "oldsubject": self.oldsubject,

--- a/src/proto_bcd/findings/finding_category.py
+++ b/src/proto_bcd/findings/finding_category.py
@@ -83,5 +83,17 @@ class FindingCategory(enum.Enum):
 
 
 class ChangeType(enum.Enum):
-    MAJOR = 1
-    MINOR = 2
+    UNDEFINED = 0
+    MAJOR = 1  # Requires SemVer major release
+    MINOR = 2  # Requires SemVer minor release
+    PATCH = 3  # Requires SemVer patch release
+    NONE = 4  # Does not require SemVer release
+
+
+class ConventionalCommitTag(enum.Enum):
+    FEAT_BREAKING = 1  # feat!: breaking change - currently unused
+    FEAT = 2  # feat: new feature, e.g. field added
+    FIX_BREAKING = 3  # fix!: breaking change, e.g. field removed
+    FIX = 4  # fix: non-breaking fix, e.g. field deprecated
+    DOCS = 5  # docs: documentation change
+    CHORE = 6  # chore: reformatting or other unrelated change

--- a/src/proto_bcd/findings/finding_container.py
+++ b/src/proto_bcd/findings/finding_container.py
@@ -15,7 +15,11 @@
 from re import sub
 from typing import Callable
 from proto_bcd.findings.finding import Finding
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ChangeType,
+    ConventionalCommitTag,
+)
 from collections import defaultdict
 
 
@@ -44,7 +48,8 @@ class FindingContainer:
         category: FindingCategory,
         proto_file_name: str,
         source_code_line: int,
-        change_type: ChangeType,
+        conventional_commit_tag: ConventionalCommitTag,
+        change_type=ChangeType.UNDEFINED,
         extra_info=None,
         subject="",
         oldsubject="",
@@ -52,13 +57,27 @@ class FindingContainer:
         type="",
         oldtype="",
     ):
+        if change_type == ChangeType.UNDEFINED:
+            if (
+                conventional_commit_tag == ConventionalCommitTag.FEAT_BREAKING
+                or conventional_commit_tag == ConventionalCommitTag.FIX_BREAKING
+            ):
+                change_type = ChangeType.MAJOR
+            elif conventional_commit_tag == ConventionalCommitTag.FEAT:
+                change_type = ChangeType.MINOR
+            elif conventional_commit_tag == ConventionalCommitTag.FIX:
+                change_type = ChangeType.PATCH
+            else:
+                change_type = ChangeType.NONE
+
         self.finding_results.append(
             Finding(
-                category,
-                proto_file_name,
-                source_code_line,
-                change_type,
-                extra_info,
+                category=category,
+                proto_file_name=proto_file_name,
+                source_code_line=source_code_line,
+                change_type=change_type,
+                conventional_commit_tag=conventional_commit_tag,
+                extra_info=extra_info,
                 subject=subject,
                 oldsubject=oldsubject,
                 context=context,

--- a/test/comparator/wrappers/__init__.py
+++ b/test/comparator/wrappers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/comparator/wrappers/test_file_set.py
+++ b/test/comparator/wrappers/test_file_set.py
@@ -97,7 +97,7 @@ class FileSetTest(unittest.TestCase):
             "hidden_message",
         )
         self.assertEqual(
-            file_set.enums_map[".example.v1.Irrelevant"].values[2].name, "GREEN"
+            file_set.enums_map[".example.v1.Irrelevant"].values["GREEN"].name, "GREEN"
         )
         self.assertEqual(
             list(file_set.services_map["ThingDoer"].methods.keys()),
@@ -222,7 +222,7 @@ class FileSetTest(unittest.TestCase):
         self.assertEqual(
             file_set.messages_map[".example.v1.OuterMessage"]
             .nested_enums["InterEnum"]
-            .values[2]
+            .values["GREEN"]
             .source_code_line,
             10,
         )

--- a/test/comparator/wrappers/test_method.py
+++ b/test/comparator/wrappers/test_method.py
@@ -159,7 +159,7 @@ class MethodTest(unittest.TestCase):
 
     def test_method_signatures(self):
         method = make_method("Method", signatures=["sig1", "sig2"])
-        self.assertEqual(method.method_signatures.value, ["sig1", "sig2"])
+        self.assertEqual(method.method_signatures.value, [("sig1",), ("sig2",)])
 
     def test_method_lro_annotationn(self):
         input_msg = make_message(name="Input", full_name=".example.v1.input")

--- a/test/findings/test_finding_container.py
+++ b/test/findings/test_finding_container.py
@@ -14,7 +14,11 @@
 
 import unittest
 from proto_bcd.findings.finding_container import FindingContainer
-from proto_bcd.findings.finding_category import FindingCategory, ChangeType
+from proto_bcd.findings.finding_category import (
+    FindingCategory,
+    ChangeType,
+    ConventionalCommitTag,
+)
 
 
 class FindingContainerTest(unittest.TestCase):
@@ -29,7 +33,7 @@ class FindingContainerTest(unittest.TestCase):
             category=FindingCategory.METHOD_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=12,
-            change_type=ChangeType.MAJOR,
+            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             subject="subject",
             context="context",
         )
@@ -40,7 +44,7 @@ class FindingContainerTest(unittest.TestCase):
             category=FindingCategory.FIELD_ADDITION,
             proto_file_name="my_proto.proto",
             source_code_line=15,
-            change_type=ChangeType.MINOR,
+            conventional_commit_tag=ConventionalCommitTag.FEAT,
         )
         self.assertEqual(len(self.finding_container.get_actionable_findings()), 1)
 
@@ -54,14 +58,14 @@ class FindingContainerTest(unittest.TestCase):
             category=FindingCategory.RESOURCE_DEFINITION_REMOVAL,
             proto_file_name="my_proto.proto",
             source_code_line=5,
-            change_type=ChangeType.MAJOR,
+            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             subject="subject",
         )
         self.finding_container.add_finding(
             category=FindingCategory.METHOD_SIGNATURE_REMOVAL,
             proto_file_name="my_other_proto.proto",
             source_code_line=-1,
-            change_type=ChangeType.MAJOR,
+            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
             type="type",
             subject="subject",
             context="context",
@@ -72,6 +76,78 @@ class FindingContainerTest(unittest.TestCase):
             + "my_proto.proto L5: An existing resource_definition `subject` is removed.\n"
             + "my_proto.proto L12: An existing method `subject` is removed from service `context`.\n",
         )
+
+    def test_change_type_major_1(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_REMOVAL,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
+            subject="subject",
+        )
+        dict_arr_output = finding_container.to_dict_arr()
+        self.assertEqual(dict_arr_output[0]["change_type"], "MAJOR")
+
+    def test_change_type_major_2(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_REMOVAL,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.FEAT_BREAKING,
+            subject="subject",
+        )
+        dict_arr_output = finding_container.to_dict_arr()
+        self.assertEqual(dict_arr_output[0]["change_type"], "MAJOR")
+
+    def test_change_type_minor(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_REMOVAL,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.FEAT,
+            subject="subject",
+        )
+        dict_arr_output = finding_container.to_dict_arr()
+        self.assertEqual(dict_arr_output[0]["change_type"], "MINOR")
+
+    def test_change_type_patch(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_REMOVAL,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.FIX,
+            subject="subject",
+        )
+        dict_arr_output = finding_container.to_dict_arr()
+        self.assertEqual(dict_arr_output[0]["change_type"], "PATCH")
+
+    def test_change_type_none_1(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_REMOVAL,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.DOCS,
+            subject="subject",
+        )
+        dict_arr_output = finding_container.to_dict_arr()
+        self.assertEqual(dict_arr_output[0]["change_type"], "NONE")
+
+    def test_change_type_none_2(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_REMOVAL,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.CHORE,
+            subject="subject",
+        )
+        dict_arr_output = finding_container.to_dict_arr()
+        self.assertEqual(dict_arr_output[0]["change_type"], "NONE")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace `change_type` (major vs minor) with `conventional_commit_tag` (for now, just `fix!:` or `feat:`). This is the first of the series of PRs to improve conventional commit message verification.

Also in this PR, fixing some incorrect comparison logic that was found during refactoring. In the two places where `MINOR` is replaced with `FIX_BREAKING`, that's LRO annotation addition and removal, which, I believe, are breaking for the client libraries.

Also in this PR, making some random changes to bring the repository back to life. I'm too lazy to move it out to a separate PR :(