### PR TITLE
feat: detect when a message is moved to another file

### DIFF
--- a/src/proto_bcd/findings/finding.py
+++ b/src/proto_bcd/findings/finding.py
@@ -38,6 +38,7 @@ class Finding:
         context="",
         type="",
         oldtype="",
+        oldcontext="",
     ):
         self.category = category
         self.location = self._Location(proto_file_name, source_code_line)
@@ -49,6 +50,7 @@ class Finding:
         self.context = context
         self.type = type
         self.oldtype = oldtype
+        self.oldcontext = oldcontext
 
     def to_dict(self):
         return {
@@ -65,6 +67,7 @@ class Finding:
             "context": self.context,
             "type": self.type,
             "oldtype": self.oldtype,
+            "oldcontext": self.oldcontext,
         }
 
     def get_message(self):

--- a/src/proto_bcd/findings/finding_category.py
+++ b/src/proto_bcd/findings/finding_category.py
@@ -46,7 +46,7 @@ class FindingCategory(enum.Enum):
     RESOURCE_DEFINITION_REMOVAL = 24
     RESOURCE_PATTERN_REMOVAL = 25
     RESOURCE_PATTERN_ADDITION = 26
-    # Messages to files mapping
+    # Messages-to-files mapping
     MESSAGE_MOVED_TO_ANOTHER_FILE = 27
     # Services
     SERVICE_ADDITION = 30

--- a/src/proto_bcd/findings/finding_category.py
+++ b/src/proto_bcd/findings/finding_category.py
@@ -46,6 +46,8 @@ class FindingCategory(enum.Enum):
     RESOURCE_DEFINITION_REMOVAL = 24
     RESOURCE_PATTERN_REMOVAL = 25
     RESOURCE_PATTERN_ADDITION = 26
+    # Messages to files mapping
+    MESSAGE_MOVED_TO_ANOTHER_FILE = 27
     # Services
     SERVICE_ADDITION = 30
     SERVICE_REMOVAL = 31

--- a/src/proto_bcd/findings/finding_container.py
+++ b/src/proto_bcd/findings/finding_container.py
@@ -56,6 +56,7 @@ class FindingContainer:
         context="",
         type="",
         oldtype="",
+        oldcontext="",
     ):
         if change_type == ChangeType.UNDEFINED:
             if (
@@ -83,6 +84,7 @@ class FindingContainer:
                 context=context,
                 type=type,
                 oldtype=oldtype,
+                oldcontext=oldcontext,
             )
         )
 

--- a/src/proto_bcd/findings/messages.py
+++ b/src/proto_bcd/findings/messages.py
@@ -79,6 +79,9 @@ _templates[
     FindingCategory.MESSAGE_REMOVAL
 ] = "An existing message `{subject}` is removed."
 _templates[
+    FindingCategory.MESSAGE_MOVED_TO_ANOTHER_FILE
+] = "An existing message `{subject}` is moved from `{oldcontext}` to `{context}`."
+_templates[
     FindingCategory.RESOURCE_DEFINITION_ADDITION
 ] = "A new resource_definition `{subject}` is added."
 _templates[

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -148,7 +148,10 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "message_v1.proto L18: An existing field `type` is removed from message `.tutorial.v1.Person`.\n"
+                "message_v1.proto L5: An existing message `Person` is moved from `message_v1.proto` to `message_v1beta1.proto`.\n"
+                + "message_v1.proto L16: An existing message `PhoneNumber` is moved from `message_v1.proto` to `message_v1beta1.proto`.\n"
+                + "message_v1.proto L18: An existing field `type` is removed from message `.tutorial.v1.Person`.\n"
+                + "message_v1.proto L27: An existing message `AddressBook` is moved from `message_v1.proto` to `message_v1beta1.proto`.\n"
                 + "message_v1beta1.proto L7: The type of an existing field `id` is changed from `int32` to `string` in message `.tutorial.v1.Person`.\n"
                 + "message_v1beta1.proto L8: An existing field `email` is renamed to `email_address` in message `.tutorial.v1.Person`.\n"
                 + "message_v1beta1.proto L21: Changed repeated flag of an existing field `phones` in message `.tutorial.v1.Person`.\n"
@@ -172,8 +175,12 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(
                 result.output,
                 "service_v1.proto L11: An existing method `ShouldRemove` is removed from service `Example`.\n"
+                + "service_v1.proto L16: An existing message `FooRequest` is moved from `service_v1.proto` to `service_v1beta1.proto`.\n"
+                + "service_v1.proto L18: An existing message `FooResponse` is moved from `service_v1.proto` to `service_v1beta1.proto`.\n"
+                + "service_v1.proto L20: An existing message `BarRequest` is moved from `service_v1.proto` to `service_v1beta1.proto`.\n"
                 + "service_v1.proto L21: An existing field `page_size` is removed from message `.example.v1.BarRequest`.\n"
                 + "service_v1.proto L22: An existing field `page_token` is removed from message `.example.v1.BarRequest`.\n"
+                + "service_v1.proto L25: An existing message `BarResponse` is moved from `service_v1.proto` to `service_v1beta1.proto`.\n"
                 + "service_v1.proto L26: An existing field `content` is removed from message `.example.v1.BarResponse`.\n"
                 + "service_v1.proto L27: An existing field `next_page_token` is removed from message `.example.v1.BarResponse`.\n"
                 + "service_v1beta1.proto L7: Input type of method `Foo` is changed from `.example.v1.FooRequest` to `.example.v1beta1.FooRequestUpdate` in service `Example`.\n"
@@ -200,6 +207,8 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(
                 result.output,
                 "service_annotation_v1.proto L18: An existing method_signature `content,error` is removed from method `Foo` in service `Example`.\n"
+                + "service_annotation_v1.proto L33: An existing message `FooRequest` is moved from `service_annotation_v1.proto` to `service_annotation_v1beta1.proto`.\n"
+                + "service_annotation_v1.proto L38: An existing message `FooResponse` is moved from `service_annotation_v1.proto` to `service_annotation_v1beta1.proto`.\n"
                 + "service_annotation_v1.proto L40: An existing message `FooMetadata` is removed.\n"
                 + "service_annotation_v1beta1.proto L14: An existing google.api.http annotation `http_method` is changed for method `Foo` in service `Example`.\n"
                 + "service_annotation_v1beta1.proto L22: An existing google.api.http annotation `http_body` is changed for method `Bar` in service `Example`.\n"
@@ -223,7 +232,9 @@ class CliDetectTest(unittest.TestCase):
             self.assertEqual(
                 result.output,
                 "signature_order_v1.proto L16: An existing method_signature `id,content` has changed its position in method `Foo` in service `Example`.\n"
-                + "signature_order_v1.proto L16: An existing method_signature `id,uri` has changed its position in method `Foo` in service `Example`.\n",
+                + "signature_order_v1.proto L16: An existing method_signature `id,uri` has changed its position in method `Foo` in service `Example`.\n"
+                + "signature_order_v1.proto L21: An existing message `FooRequest` is moved from `signature_order_v1.proto` to `signature_order_v1beta1.proto`.\n"
+                + "signature_order_v1.proto L29: An existing message `FooResponse` is moved from `signature_order_v1.proto` to `signature_order_v1beta1.proto`.\n",
             )
 
     def test_oslogin_proto_alpha(self):

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -157,6 +157,7 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         # The breaking change should be in field level, instead of message removal,
         # since the message is imported from dependency file.
+        # One more breaking change is caused by the filename change.
         breaking = self.finding_container.get_actionable_findings()
         self.assertEqual(len(breaking), 2)
         self.assertEqual(breaking[0].category.name, "MESSAGE_MOVED_TO_ANOTHER_FILE")
@@ -233,6 +234,7 @@ class FileSetComparatorTest(unittest.TestCase):
         ).compare()
         # The breaking change should be in field level, instead of message removal,
         # since the message is imported from dependency file.
+        # One more breaking change is caused by the filename change.
         breaking = self.finding_container.get_actionable_findings()
         self.assertEqual(len(breaking), 2)
         self.assertEqual(breaking[0].category.name, "MESSAGE_MOVED_TO_ANOTHER_FILE")

--- a/test/comparator/test_resources.py
+++ b/test/comparator/test_resources.py
@@ -124,7 +124,13 @@ class ResourceReferenceTest(unittest.TestCase):
         # 2. File-level resource definition `t2` is removed, but is added
         # to message-level resource. Non-breaking change.
         breaking_changes = self.finding_container.get_actionable_findings()
-        self.assertEqual(len(breaking_changes), 1)
+        self.assertEqual(len(breaking_changes), 2)
+        self.assertEquals(
+            breaking_changes[0].category.name, "MESSAGE_MOVED_TO_ANOTHER_FILE"
+        )
+        self.assertEquals(
+            breaking_changes[1].category.name, "RESOURCE_REFERENCE_CHANGE_CHILD_TYPE"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #233. Apparently, the internal `Message` class has a field `proto_file_name` which allows us to add this check pretty easily.