### PR TITLE
feat: CLI flag and a method to return all changes

### DIFF
--- a/src/proto_bcd/cli/detect.py
+++ b/src/proto_bcd/cli/detect.py
@@ -59,6 +59,12 @@ from proto_bcd.detector.detector import Detector
     is_flag=True,
     help="Show line numbers in the human readable output. True by default, use --no_line_numbers to disable.",
 )
+@click.option(
+    "--all_changes",
+    default=False,
+    is_flag=True,
+    help="Show all changes between two API definitions, not only breaking changes.",
+)
 def detect(
     original_api_definition_dirs: str,
     update_api_definition_dirs: str,
@@ -69,6 +75,7 @@ def detect(
     output_json_path: str,
     human_readable_message: bool,
     line_numbers: bool,
+    all_changes: bool,
 ):
     """Detect the breaking changes of the original and updated versions of API definition files."""
     # 1. Read the stdin options and create the Options object for all the command args.
@@ -85,6 +92,7 @@ def detect(
         human_readable_message=human_readable_message,
         output_json_path=output_json_path,
         line_numbers=line_numbers,
+        all_changes=all_changes,
     )
     # 3. Create protoc command (back up solution) to load the FileDescriptorSet.
     # It takes options, returns file_descriptor_set.
@@ -111,10 +119,13 @@ def detect(
             descriptor_set=None,
         ).get_descriptor_set()
     # 4. Create the detector with two FileDescriptorSet and options.
-    # It creates output_json file and prints human-readable message if the option is enabled.
-    result = Detector(
-        file_set_original, file_set_update, options
-    ).detect_breaking_changes()
+    detector = Detector(file_set_original, file_set_update, options)
+    # 5. Invoke the detector. It creates output_json file and prints
+    # human-readable message if the option is enabled.
+    if all_changes:
+        result = detector.detect_all_changes()
+    else:
+        result = detector.detect_breaking_changes()
     return len(result)
 
 

--- a/src/proto_bcd/detector/detector.py
+++ b/src/proto_bcd/detector/detector.py
@@ -36,13 +36,15 @@ class Detector:
         self.opts = opts
         self.finding_container = FindingContainer()
 
-    def detect_breaking_changes(self):
+    def _compare(self):
         # Init FileSetComparator and compare the two FileDescriptorSet.
-        FileSetComparator(
+        # Result is stored in self.finding_container, and printed to stdout if requested.
+        comparator = FileSetComparator(
             FileSet(self.descriptor_set_original),
             FileSet(self.descriptor_set_update),
             self.finding_container,
-        ).compare()
+        )
+        comparator.compare()
 
         if self.opts and self.opts.output_json_path:
             # Output json file of findings and human-readable messages if the
@@ -55,8 +57,15 @@ class Detector:
         if self.opts and self.opts.human_readable_message:
             sys.stdout.write(
                 self.finding_container.to_human_readable_message(
-                    line_numbers=self.opts.line_numbers
+                    line_numbers=self.opts.line_numbers,
+                    all_changes=self.opts.all_changes,
                 )
             )
 
+    def detect_breaking_changes(self):
+        self._compare()
         return self.finding_container.get_actionable_findings()
+
+    def detect_all_changes(self):
+        self._compare()
+        return self.finding_container.get_all_findings()

--- a/src/proto_bcd/detector/options.py
+++ b/src/proto_bcd/detector/options.py
@@ -33,6 +33,7 @@ class Options:
                       we will create a json for the users which is in
                       `$root/detected_breaking_changes.json`.
     line_numbers: Show line numbers from the human readable output. True by default.
+    all_changes: Show all changes, not only breaking changes. False by default.
     """
 
     def __init__(
@@ -46,6 +47,7 @@ class Options:
         human_readable_message: bool = False,
         output_json_path: Optional[str] = None,
         line_numbers: bool = True,
+        all_changes: bool = False,
     ):
         self.original_api_definition_dirs = self._get_arg_arr(
             original_api_definition_dirs
@@ -63,6 +65,7 @@ class Options:
         self.human_readable_message = human_readable_message
         self.output_json_path = self._get_output_json_path(output_json_path)
         self.line_numbers = line_numbers
+        self.all_changes = all_changes
 
     def use_proto_dirs(self) -> bool:
         # User pass in the directorirs of proto definition files as input.

--- a/src/proto_bcd/findings/finding_container.py
+++ b/src/proto_bcd/findings/finding_container.py
@@ -99,10 +99,14 @@ class FindingContainer:
     def to_dict_arr(self):
         return [finding.to_dict() for finding in self.finding_results]
 
-    def to_human_readable_message(self, line_numbers=True):
+    def to_human_readable_message(self, line_numbers=True, all_changes=False):
         output_message = ""
         file_to_findings = defaultdict(list)
-        for finding in self.get_actionable_findings():
+        if all_changes:
+            findings = self.get_all_findings()
+        else:
+            findings = self.get_actionable_findings()
+        for finding in findings:
             # Create a map to summarize the findings based on proto file name.
             file_to_findings[finding.location.proto_file_name].append(finding)
         # Add each finding to the output message.

--- a/test/cli/test_detect.py
+++ b/test/cli/test_detect.py
@@ -388,6 +388,42 @@ class CliDetectTest(unittest.TestCase):
                 + "google/cloud/texttospeech/v1beta1/cloud_tts.proto: An existing message `Timepoint` is removed.\n",
             )
 
+    def test_nonbreaking_changes_not_reported(self):
+        with patch("sys.stdout", new=StringIO()):
+            runner = CliRunner()
+            result = runner.invoke(
+                detect,
+                [
+                    "--original_api_definition_dirs=test/testdata/protos/nonbreaking/old",
+                    "--update_api_definition_dirs=test/testdata/protos/nonbreaking/new",
+                    "--original_proto_files=test/testdata/protos/nonbreaking/old/file.proto",
+                    "--update_proto_files=test/testdata/protos/nonbreaking/new/file.proto",
+                    "--human_readable_message",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.output, "")
+
+    def test_nonbreaking_changes_reported_if_requested(self):
+        with patch("sys.stdout", new=StringIO()):
+            runner = CliRunner()
+            result = runner.invoke(
+                detect,
+                [
+                    "--original_api_definition_dirs=test/testdata/protos/nonbreaking/old",
+                    "--update_api_definition_dirs=test/testdata/protos/nonbreaking/new",
+                    "--original_proto_files=test/testdata/protos/nonbreaking/old/file.proto",
+                    "--update_proto_files=test/testdata/protos/nonbreaking/new/file.proto",
+                    "--human_readable_message",
+                    "--all_changes",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                "file.proto L7: A new field `added` is added to message `.test_non_breaking.Message`.\n",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/detector/test_detector.py
+++ b/test/detector/test_detector.py
@@ -105,6 +105,24 @@ class DectetorTest(unittest.TestCase):
             breaking_changes[0].get_message(), "An existing enum `foo` is removed."
         )
 
+    def test_detector_all_changes(self):
+        # Mock original and updated FileDescriptorSet.
+        enum_original = make_enum(name="foo", values=[("A", 1)])
+        enum_update = make_enum(name="foo", values=[("A", 1), ("B", 2)])
+        file_set_original = desc.FileDescriptorSet(
+            file=[make_file_pb2(name="file.proto", enums=[enum_original])]
+        )
+        file_set_update = desc.FileDescriptorSet(
+            file=[make_file_pb2(name="file.proto", enums=[enum_update])]
+        )
+        breaking_changes = Detector(
+            file_set_original, file_set_update
+        ).detect_breaking_changes()
+        # Without options, the detector returns an array of actionable Findings.
+        self.assertEqual(len(breaking_changes), 0)
+        all_changes = Detector(file_set_original, file_set_update).detect_all_changes()
+        self.assertEqual(len(all_changes), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/findings/test_finding_container.py
+++ b/test/findings/test_finding_container.py
@@ -149,6 +149,20 @@ class FindingContainerTest(unittest.TestCase):
         dict_arr_output = finding_container.to_dict_arr()
         self.assertEqual(dict_arr_output[0]["change_type"], "NONE")
 
+    def test_human_readable_message_for_all_findings(self):
+        finding_container = FindingContainer()
+        finding_container.add_finding(
+            category=FindingCategory.METHOD_ADDTION,
+            proto_file_name="test.proto",
+            source_code_line=1,
+            conventional_commit_tag=ConventionalCommitTag.FEAT,
+            subject="subject",
+        )
+        message = finding_container.to_human_readable_message(all_changes=True)
+        self.assertEqual(
+            message, "test.proto L1: A new method `subject` is added to service ``.\n"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/testdata/protos/nonbreaking/new/file.proto
+++ b/test/testdata/protos/nonbreaking/new/file.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package test_non_breaking;
+
+message Message {
+  string field = 1;
+  string added = 2;
+}

--- a/test/testdata/protos/nonbreaking/old/file.proto
+++ b/test/testdata/protos/nonbreaking/old/file.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test_non_breaking;
+
+message Message {
+  string field = 1;
+}


### PR DESCRIPTION
For validating release notes, we'll need to know all changes made to the given API, not just breaking changes.

Note: documentation changes are not currently detected by BCD, but I want to start detecting what we can, and then add docs parsing (which might get somewhat tricky).