### PR TITLE
feat: warn on resource pattern reorder

### DIFF
--- a/src/proto_bcd/comparator/file_set_comparator.py
+++ b/src/proto_bcd/comparator/file_set_comparator.py
@@ -302,6 +302,29 @@ class FileSetComparator:
                     subject=resource_type,
                     conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
                 )
+            num_original = len(patterns_original)
+            num_update = len(patterns_update)
+            # Order of patterns changed
+            if (  # new pattern inserted rather than appended
+                num_original < num_update
+                and patterns_original != patterns_update[: num_original - 1]
+            ) or (  # existing patterns moved in place
+                num_original == num_update
+                and len(set(patterns_original) - set(patterns_update)) == 0
+                and patterns_original != patterns_update
+            ):
+                self.finding_container.add_finding(
+                    category=FindingCategory.RESOURCE_PATTERN_REORDER,
+                    proto_file_name=resources_original.types[
+                        resource_type
+                    ].proto_file_name,
+                    source_code_line=resources_original.types[
+                        resource_type
+                    ].source_code_line,
+                    type=resource_type,
+                    subject=resource_type,
+                    conventional_commit_tag=ConventionalCommitTag.FIX_BREAKING,
+                )
 
         # 2. File-level resource definitions addition.
         for resource_type in resources_types_update - resources_types_original:

--- a/src/proto_bcd/comparator/file_set_comparator.py
+++ b/src/proto_bcd/comparator/file_set_comparator.py
@@ -306,7 +306,6 @@ class FileSetComparator:
             num_update = len(patterns_update)
             # This check is for detecting changes to the order of the patterns
             # which is considered a breaking change.
-            # For more information, see <link to issue>.
             # Check if a new pattern is inserted rather than appended or
             # if the order of patterns has changed in place.
             if (

--- a/src/proto_bcd/comparator/file_set_comparator.py
+++ b/src/proto_bcd/comparator/file_set_comparator.py
@@ -305,9 +305,9 @@ class FileSetComparator:
             num_original = len(patterns_original)
             num_update = len(patterns_update)
             # This check is for detecting changes to the order of the patterns
-            # which is considered a breaking change. 
+            # which is considered a breaking change.
             # For more information, see <link to issue>.
-            # Check if a new pattern is inserted rather than appended or 
+            # Check if a new pattern is inserted rather than appended or
             # if the order of patterns has changed in place.
             if (
                 num_original < num_update

--- a/src/proto_bcd/comparator/file_set_comparator.py
+++ b/src/proto_bcd/comparator/file_set_comparator.py
@@ -304,13 +304,16 @@ class FileSetComparator:
                 )
             num_original = len(patterns_original)
             num_update = len(patterns_update)
-            # Order of patterns changed
-            if (  # new pattern inserted rather than appended
+            # This check is for detecting changes to the order of the patterns
+            # which is considered a breaking change. 
+            # For more information, see <link to issue>.
+            # Check if a new pattern is inserted rather than appended or 
+            # if the order of patterns has changed in place.
+            if (
                 num_original < num_update
-                and patterns_original != patterns_update[: num_original - 1]
-            ) or (  # existing patterns moved in place
-                num_original == num_update
-                and len(set(patterns_original) - set(patterns_update)) == 0
+                and patterns_original != patterns_update[:num_original]
+            ) or (
+                set(patterns_original) == set(patterns_update)
                 and patterns_original != patterns_update
             ):
                 self.finding_container.add_finding(

--- a/src/proto_bcd/findings/finding_category.py
+++ b/src/proto_bcd/findings/finding_category.py
@@ -47,6 +47,7 @@ class FindingCategory(enum.Enum):
     RESOURCE_DEFINITION_REMOVAL = 24
     RESOURCE_PATTERN_REMOVAL = 25
     RESOURCE_PATTERN_ADDITION = 26
+    RESOURCE_PATTERN_REORDER = 28
     # Messages-to-files mapping
     MESSAGE_MOVED_TO_ANOTHER_FILE = 27
     # Services

--- a/src/proto_bcd/findings/messages.py
+++ b/src/proto_bcd/findings/messages.py
@@ -94,6 +94,9 @@ _templates[
     FindingCategory.RESOURCE_PATTERN_REMOVAL
 ] = "An existing resource pattern value `{type}` from the resource definition `{subject}` is removed."
 _templates[
+    FindingCategory.RESOURCE_PATTERN_REORDER
+] = "An existing resource's patterns were reordered in `{subject}`."
+_templates[
     FindingCategory.RESOURCE_PATTERN_ADDITION
 ] = "A new resource pattern value `{type}` added to the resource definition `{subject}`."
 _templates[FindingCategory.SERVICE_ADDITION] = "A new service `{subject}` is added."

--- a/test/comparator/test_file_set_comparator.py
+++ b/test/comparator/test_file_set_comparator.py
@@ -300,6 +300,66 @@ class FileSetComparatorTest(unittest.TestCase):
             "foo.proto",
         )
 
+    def test_resources_existing_patterns_reorder_in_place(self):
+        options_original = make_file_options_resource_definition(
+            resource_type=".example.v1.Bar",
+            resource_patterns=["bars/{bar}", "foos/{foo}"],
+        )
+        file_pb2 = make_file_pb2(
+            name="foo.proto", package=".example.v1", options=options_original
+        )
+        file_set_original = make_file_set(files=[file_pb2])
+
+        options_update = make_file_options_resource_definition(
+            resource_type=".example.v1.Bar",
+            resource_patterns=["foos/{foo}", "bars/{bar}"],
+        )
+        file_pb2 = make_file_pb2(
+            name="foo.proto", package=".example.v1", options=options_update
+        )
+        file_set_update = make_file_set(files=[file_pb2])
+
+        FileSetComparator(
+            file_set_original, file_set_update, self.finding_container
+        ).compare()
+        finding = self.finding_container.get_all_findings()[0]
+        self.assertEqual(finding.change_type.name, "MAJOR")
+        self.assertEqual(finding.category.name, "RESOURCE_PATTERN_REORDER")
+        self.assertEqual(
+            finding.location.proto_file_name,
+            "foo.proto",
+        )
+
+    def test_resources_existing_patterns_reorder_insertion(self):
+        options_original = make_file_options_resource_definition(
+            resource_type=".example.v1.Bar",
+            resource_patterns=["bars/{bar}", "foos/{foo}"],
+        )
+        file_pb2 = make_file_pb2(
+            name="foo.proto", package=".example.v1", options=options_original
+        )
+        file_set_original = make_file_set(files=[file_pb2])
+
+        options_update = make_file_options_resource_definition(
+            resource_type=".example.v1.Bar",
+            resource_patterns=["foos/{foo}", "bizs/{biz}", "bars/{bar}"],
+        )
+        file_pb2 = make_file_pb2(
+            name="foo.proto", package=".example.v1", options=options_update
+        )
+        file_set_update = make_file_set(files=[file_pb2])
+
+        FileSetComparator(
+            file_set_original, file_set_update, self.finding_container
+        ).compare()
+        finding = self.finding_container.get_all_findings()[0]
+        self.assertEqual(finding.change_type.name, "MAJOR")
+        self.assertEqual(finding.category.name, "RESOURCE_PATTERN_REORDER")
+        self.assertEqual(
+            finding.location.proto_file_name,
+            "foo.proto",
+        )
+
     def test_resources_addition(self):
         file_set_original = make_file_set(
             files=[make_file_pb2(name="foo.proto", package=".example.v1")]


### PR DESCRIPTION
We need to warn about `pattern` reordering in `google.api.resource` annotations. A new`pattern` must always be appended, so _inserting_ a new `pattern` ahead of or in between existing `pattern`(s) or simply rearrange existing `pattern`s is disallowed.

Internal bug http://b/356395033