### PR TITLE
fix: require min py 3.9 and test with newer runtimes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     name="proto-breaking-change-detector",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
+    python_requires=">=3.9",
     version=version,
     install_requires=[
         "Click",


### PR DESCRIPTION
Require minimum python 3.9.

Drop Python 3.7 and 3.8 in CI, replacing with 3.11 and 3.12. So tested runtimes are 3.9 -> 3.12.