### PR TITLE
build: Trigger presubmit workflows on GitHub merge queue events

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Trigger workflow on GitHub merge queue events
+  # See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   build:


### PR DESCRIPTION
This will allow us to use Github Merge Queues to avoid having to update PRs manually

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group which mentions the following:

>More than one activity type triggers this event. Although only the checks_requested activity type is supported, specifying the activity type will keep your workflow specific if more activity types are added in the future. 

>If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The merge_group event is separate from the pull_request and push events.