### PR TITLE
Add a suppression to avoid breaking builds for pytype with 3.12 support

### DIFF
--- a/src/proto_bcd/comparator/wrappers.py
+++ b/src/proto_bcd/comparator/wrappers.py
@@ -964,12 +964,16 @@ class FileSet:
                 for _, field in message.fields.items():
                     # If the field is a map type, the message type is auto-generated.
                     if field.is_map_type:
+                        # pytype: disable=attribute-error
                         for _, entry_type in field.map_entry_type.items():
+                            # pytype: enable=attribute-error
                             self._register_field(entry_type)
                     elif not field.is_primitive_type:
                         # If the field is not a map and primitive type, add the
                         # referenced type to map.
+                        # pytype: disable=attribute-error
                         self._register_field(field.type_name.value)
+                        # pytype: enable=attribute-error
                 message_stack.extend(list(message.nested_messages.values()))
 
     def _register_field(self, register_type):


### PR DESCRIPTION
Hi, I'm with the python-team@google.

I'm on my way to enabling pytype 3.12 at Google, and noticed this type error, would you mind accepting this change so that we can unblock relesing pytype 3.12 at Google.?

